### PR TITLE
fix(net worth history): clamp AI history windows and net-worth backfill to stop runaway fetches

### DIFF
--- a/server/ai/tools/helpers/time-range.ts
+++ b/server/ai/tools/helpers/time-range.ts
@@ -1,0 +1,58 @@
+import { format, isValid, parseISO, subDays } from "date-fns";
+
+export const DEFAULT_MAX_HISTORY_DAYS = 365; // ~1 year
+
+interface ClampDaysBackOptions {
+  requested: number | null | undefined;
+  min?: number;
+  max?: number;
+}
+
+export function clampDaysBack({
+  requested,
+  min = 1,
+  max = DEFAULT_MAX_HISTORY_DAYS,
+}: ClampDaysBackOptions): number {
+  const value =
+    typeof requested === "number" ? requested : DEFAULT_MAX_HISTORY_DAYS;
+  const bounded = Math.min(Math.max(min, Math.trunc(value)), max);
+  return bounded;
+}
+
+interface ClampDateRangeOptions {
+  startDate: string | null | undefined;
+  endDate: string | null | undefined;
+  maxDays?: number;
+}
+
+export function clampDateRange({
+  startDate,
+  endDate,
+  maxDays = DEFAULT_MAX_HISTORY_DAYS,
+}: ClampDateRangeOptions): { startDate: string; endDate: string } {
+  const today = new Date();
+  const parsedEnd = endDate ? parseISO(endDate) : today;
+  const safeEnd = isValid(parsedEnd)
+    ? parsedEnd > today
+      ? today
+      : parsedEnd
+    : today;
+
+  const maxLookbackStart = subDays(safeEnd, Math.max(0, maxDays - 1));
+
+  const parsedStart = startDate ? parseISO(startDate) : maxLookbackStart;
+  let safeStart = isValid(parsedStart) ? parsedStart : maxLookbackStart;
+
+  if (safeStart > safeEnd) {
+    safeStart = maxLookbackStart;
+  }
+
+  if (safeStart < maxLookbackStart) {
+    safeStart = maxLookbackStart;
+  }
+
+  return {
+    startDate: format(safeStart, "yyyy-MM-dd"),
+    endDate: format(safeEnd, "yyyy-MM-dd"),
+  };
+}

--- a/server/ai/tools/net-worth-change.ts
+++ b/server/ai/tools/net-worth-change.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { fetchNetWorthChange } from "@/server/analysis/net-worth-change";
+import { clampDaysBack } from "@/server/ai/tools/helpers/time-range";
 
 interface GetNetWorthChangeParams {
   baseCurrency: string | null;
@@ -9,7 +10,7 @@ interface GetNetWorthChangeParams {
 
 export async function getNetWorthChange(params: GetNetWorthChangeParams) {
   const baseCurrency = params.baseCurrency ?? undefined;
-  const daysBack = params.daysBack ?? 180;
+  const daysBack = clampDaysBack({ requested: params.daysBack });
 
   const change = await fetchNetWorthChange({
     targetCurrency: baseCurrency,

--- a/server/ai/tools/net-worth-history.ts
+++ b/server/ai/tools/net-worth-history.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { fetchNetWorthHistory } from "@/server/analysis/net-worth-history";
+import { clampDaysBack } from "@/server/ai/tools/helpers/time-range";
 
 interface GetNetWorthHistoryParams {
   baseCurrency: string | null;
@@ -9,7 +10,7 @@ interface GetNetWorthHistoryParams {
 
 export async function getNetWorthHistory(params: GetNetWorthHistoryParams) {
   const baseCurrency = params.baseCurrency ?? undefined;
-  const daysBack = params.daysBack ?? 180;
+  const daysBack = clampDaysBack({ requested: params.daysBack });
 
   const history = await fetchNetWorthHistory({
     targetCurrency: baseCurrency,

--- a/server/ai/tools/portfolio-records.ts
+++ b/server/ai/tools/portfolio-records.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { fetchPortfolioRecords } from "@/server/portfolio-records/fetch";
+import { clampDateRange } from "@/server/ai/tools/helpers/time-range";
 
 import type { PortfolioRecordWithPosition } from "@/types/global.types";
 
@@ -15,8 +16,14 @@ export async function getPortfolioRecords(params: GetPortfolioRecordsParams) {
   const positionId = params.positionId ?? undefined;
   const includeArchived = params.includeArchived ?? undefined;
 
-  const startDate = params.startDate ? new Date(params.startDate) : undefined;
-  const endDate = params.endDate ? new Date(params.endDate) : undefined;
+  const { startDate: startDateKey, endDate: endDateKey } = clampDateRange({
+    startDate: params.startDate,
+    endDate: params.endDate,
+    maxDays: positionId ? 730 : undefined,
+  });
+
+  const startDate = startDateKey ? new Date(startDateKey) : undefined;
+  const endDate = endDateKey ? new Date(endDateKey) : undefined;
 
   const pageSize = 100;
   let page = 1;
@@ -56,8 +63,8 @@ export async function getPortfolioRecords(params: GetPortfolioRecordsParams) {
     total: allRecords.length,
     returned: items.length,
     range: {
-      start: startDate ?? null,
-      end: endDate ?? null,
+      start: startDate?.toISOString().split("T")[0] ?? null,
+      end: endDate?.toISOString().split("T")[0] ?? null,
     },
     positionId: params.positionId,
     includeArchived: params.includeArchived ?? true,

--- a/server/ai/tools/projected-income.ts
+++ b/server/ai/tools/projected-income.ts
@@ -11,7 +11,7 @@ interface GetProjectedIncomeParams {
 export async function getProjectedIncome(params: GetProjectedIncomeParams) {
   const baseCurrency =
     params.baseCurrency ?? (await fetchProfile()).profile.display_currency;
-  const monthsAhead = params.monthsAhead ?? 12;
+  const monthsAhead = Math.min(Math.max(params.monthsAhead ?? 12, 1), 24);
 
   const result = await calculateProjectedIncome(baseCurrency, monthsAhead);
 


### PR DESCRIPTION
Add shared time-range guards for AI tools (net worth, change, performance, records, snapshots, income), cap requests to ~1 year by default, allow longer spans only where safe, and update net-worth history to process only real snapshot ranges while padding earlier dates with zeros. This prevents massive FX/market backfills yet preserving UI timelines.