### PR TITLE
feat(seo): add page metadata and dynamic portfolio titles

### DIFF
--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 
@@ -5,6 +6,12 @@ import { Logo } from "@/components/ui/logos/logo";
 import { ResetPasswordForm } from "@/components/features/auth/forgot-password-form";
 
 import { createClient } from "@/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Forgot Password",
+  description:
+    "Recover your account if you've lost or forgotten your password.",
+};
 
 export default async function ForgotPasswordPage() {
   // Check if user is already logged in and redirect to dashboard

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 
@@ -6,6 +7,11 @@ import { Logo } from "@/components/ui/logos/logo";
 import { LoginForm } from "@/components/features/auth/login-form";
 
 import { createClient } from "@/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Login",
+  description: "Sign in to your Foliofox account.",
+};
 
 export default async function LoginPage() {
   // Check if user is already logged in and redirect to dashboard

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 
@@ -5,6 +6,11 @@ import { Logo } from "@/components/ui/logos/logo";
 import { SignupForm } from "@/components/features/auth/signup-form";
 
 import { createClient } from "@/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Signup",
+  description: "Create a new free account on Foliofox.",
+};
 
 export default async function SignupPage() {
   // Check if user is already logged in and redirect to dashboard

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,12 +11,15 @@ import { getOptionalUser } from "@/server/auth/actions";
 import "./globals.css";
 
 const manrope = Manrope({
-  variable: "--font-manrope",
   subsets: ["latin"],
+  variable: "--font-manrope",
 });
 
 export const metadata: Metadata = {
-  title: "Foliofox - Portfolio Intelligence Platform",
+  title: {
+    default: "Foliofox - The AI-Powered Portfolio Intelligence Platform",
+    template: "%s - Foliofox",
+  },
   description:
     "Comprehensive portfolio tracking and AI-powered financial planning. Monitor your holdings, analyze performance, and discover growth opportunities with predictive insights tailored to your wealth-building strategy.",
 };
@@ -44,7 +47,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${manrope.variable} antialiased transition-all`}>
+      <body className={`${manrope.variable} antialiased`}>
         <Suspense>
           <PostHogUserProvider>
             <ThemeProvider

--- a/app/portfolio/[slug]/page.tsx
+++ b/app/portfolio/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import Link from "next/link";
@@ -18,6 +19,33 @@ import { fetchPositions } from "@/server/positions/fetch";
 import { calculateProfitLoss } from "@/lib/profit-loss";
 
 import type { PositionsQueryContext } from "@/server/positions/fetch";
+
+// --- Metadata Generation ---
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+
+  const resolved = await fetchPublicPortfolioBySlug(slug);
+
+  if (!resolved || !resolved.isActive) {
+    return {
+      title: "Public Portfolio",
+      description: "View this public portfolio on Foliofox.",
+    };
+  }
+
+  const { profile } = resolved;
+  const username = profile.username;
+
+  return {
+    title: `${username}'s Portfolio`,
+    description: `View ${username}'s public portfolio on Foliofox. Track positions, asset allocation, and performance insights.`,
+  };
+}
 
 // --- Wrapper Components ---
 


### PR DESCRIPTION
- Add metadata to auth pages (login, signup, forgot-password)
- Implement title template in root layout for consistent branding
- Add dynamic metadata generation for public portfolio pages
- Cache fetchPublicPortfolioBySlug to avoid duplicate requests between metadata and page rendering