### PR TITLE
test: number parser

### DIFF
--- a/lib/import/parser/number-parser.test.ts
+++ b/lib/import/parser/number-parser.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { parseNumberStrict } from "./number-parser";
+
+describe("parseNumberStrict", () => {
+  it("should return NaN for non-numeric strings", () => {
+    expect(parseNumberStrict("abc")).toBeNaN();
+    expect(parseNumberStrict("xyz")).toBeNaN();
+    expect(parseNumberStrict("hello")).toBeNaN();
+  });
+
+  it("should return NaN for empty strings", () => {
+    expect(parseNumberStrict("")).toBeNaN();
+    expect(parseNumberStrict("   ")).toBeNaN();
+  });
+
+  it("should parse simple integer strings", () => {
+    expect(parseNumberStrict("123")).toBe(123);
+    expect(parseNumberStrict("0")).toBe(0);
+    expect(parseNumberStrict("-45")).toBe(-45);
+  });
+
+  it("should parse US format decimals", () => {
+    expect(parseNumberStrict("123.45")).toBe(123.45);
+    expect(parseNumberStrict("1,234.56")).toBe(1234.56);
+    expect(parseNumberStrict("52,673.82")).toBe(52673.82);
+  });
+
+  it("should parse EU format decimals", () => {
+    expect(parseNumberStrict("123,45")).toBe(123.45);
+    expect(parseNumberStrict("1.234,56")).toBe(1234.56);
+    expect(parseNumberStrict("52.673,82")).toBe(52673.82);
+  });
+
+  it("should handle numbers without thousands separators", () => {
+    expect(parseNumberStrict("1234.56")).toBe(1234.56);
+    expect(parseNumberStrict("1234,56")).toBe(1234.56);
+  });
+
+  it("should parse negative numbers", () => {
+    expect(parseNumberStrict("-123.45")).toBe(-123.45);
+    expect(parseNumberStrict("-1,234.56")).toBe(-1234.56);
+    expect(parseNumberStrict("-1.234,56")).toBe(-1234.56);
+  });
+
+  it("should handle numbers with spaces", () => {
+    expect(parseNumberStrict(" 123.45 ")).toBe(123.45);
+    expect(parseNumberStrict("1 234.56")).toBe(1234.56);
+  });
+
+  it("should return NaN for mixed invalid characters", () => {
+    expect(parseNumberStrict("12abc34")).toBeNaN();
+    expect(parseNumberStrict("1a2b3c4")).toBeNaN();
+  });
+
+  it("should handle currency symbols at start or end", () => {
+    expect(parseNumberStrict("$100")).toBe(100);
+    expect(parseNumberStrict("100$")).toBe(100);
+    expect(parseNumberStrict("€123.45")).toBe(123.45);
+    expect(parseNumberStrict("123.45€")).toBe(123.45);
+    expect(parseNumberStrict("£1,234.56")).toBe(1234.56);
+    expect(parseNumberStrict("1.234,56 EUR")).toBe(1234.56);
+  });
+
+  it("should handle zero values", () => {
+    expect(parseNumberStrict("0")).toBe(0);
+    expect(parseNumberStrict("0.0")).toBe(0);
+    expect(parseNumberStrict("0,0")).toBe(0);
+  });
+
+  it("should return NaN for multiple decimal separators of same type", () => {
+    expect(parseNumberStrict("1.2.3")).toBeNaN();
+    expect(parseNumberStrict("1,2,3,4")).toBeNaN();
+  });
+
+  it("should handle very large numbers", () => {
+    expect(parseNumberStrict("1000000.99")).toBe(1000000.99);
+    expect(parseNumberStrict("1.000.000,99")).toBe(1000000.99);
+  });
+});

--- a/lib/import/parser/number-parser.ts
+++ b/lib/import/parser/number-parser.ts
@@ -9,29 +9,45 @@ export function parseNumberStrict(raw: string): number {
   const hasComma = input.includes(",");
   const hasDot = input.includes(".");
 
-  let normalized = input;
+  // Strip leading/trailing non-numeric characters (currency symbols, spaces, etc)
+  let normalized = input
+    .replace(/^[^\d\-\.,]*/g, "")
+    .replace(/[^\d\.,]*$/g, "");
+
+  // Check for unexpected characters in the middle of the input
+  // Allow only: digits, leading minus, comma, dot, and spaces
+  if (!/^-?[\d\s.,]*$/.test(normalized)) {
+    return NaN;
+  }
 
   if (hasComma && !hasDot) {
     // EU: "52.673,82" or "52673,82" (dots might be thousands)
-    normalized = input.replace(/\./g, "").replace(",", ".");
+    // But reject if multiple commas (e.g., "1,2,3,4")
+    if ((normalized.match(/,/g) || []).length > 1) return NaN;
+    normalized = normalized.replace(/\./g, "").replace(",", ".");
   } else if (!hasComma && hasDot) {
     // US: "52,673.82" or "52673.82" (commas might be thousands)
-    normalized = input.replace(/,/g, "");
+    // But reject if multiple dots (e.g., "1.2.3.4")
+    if ((normalized.match(/\./g) || []).length > 1) return NaN;
+    normalized = normalized.replace(/,/g, "");
   } else if (hasComma && hasDot) {
     // Decide by last separator position
-    const lastComma = input.lastIndexOf(",");
-    const lastDot = input.lastIndexOf(".");
+    const lastComma = normalized.lastIndexOf(",");
+    const lastDot = normalized.lastIndexOf(".");
     if (lastComma > lastDot) {
       // Comma decimal → remove dots as thousands, comma -> dot
-      normalized = input.replace(/\./g, "").replace(",", ".");
+      normalized = normalized.replace(/\./g, "").replace(",", ".");
     } else {
       // Dot decimal → remove commas as thousands
-      normalized = input.replace(/,/g, "");
+      normalized = normalized.replace(/,/g, "");
     }
   }
 
-  // Strip remaining non-numeric chars (allow leading minus and dot)
-  normalized = normalized.replace(/[^0-9.\-]/g, "");
+  // Strip remaining non-numeric chars (spaces and separators already validated)
+  normalized = normalized.replace(/[\s]/g, "");
+
+  // If nothing remains after stripping, it's invalid
+  if (!normalized || normalized === "-" || normalized === ".") return NaN;
 
   const result = Number(normalized);
   return Number.isFinite(result) ? result : NaN;


### PR DESCRIPTION
This pull request improves the robustness and correctness of the `parseNumberStrict` function for parsing numeric strings, and adds a comprehensive test suite to ensure its behavior across various input formats and edge cases.

### Parsing logic improvements

* Enhanced input normalization by stripping leading/trailing non-numeric characters (e.g., currency symbols, spaces), and validating that only allowed characters are present in the middle of the input. This prevents invalid parsing for strings with mixed characters.
* Added checks to reject numbers with multiple decimal separators of the same type (e.g., `"1.2.3"`, `"1,2,3,4"`), improving error handling for malformed numbers.
* Ensured that empty or invalid strings (including those that reduce to `"-"` or `"."`) return `NaN`, increasing reliability.

Requires:
* https://github.com/unav4ila8le/foliofox/pull/62

ref: https://github.com/unav4ila8le/foliofox/issues/64