### PR TITLE
Fix privacy mode for absolute change in dashboard

### DIFF
--- a/components/dashboard/charts/net-worth-area.tsx
+++ b/components/dashboard/charts/net-worth-area.tsx
@@ -190,10 +190,9 @@ export function NetWorthAreaChart({
                         <TrendingDown className="size-4" />
                       )}
                       <span>
-                        {change.absoluteChange >= 0 ? "+" : ""}
-                        {formatNumber(change.absoluteChange, undefined, {
-                          maximumFractionDigits: 2,
-                        })}{" "}
+                        {isPrivacyMode
+                          ? "* * * * * *"
+                          : `${change.absoluteChange >= 0 ? "+" : ""}${formatNumber(change.absoluteChange, undefined, { maximumFractionDigits: 2 })}`}{" "}
                         ({change.percentageChange >= 0 ? "+" : ""}
                         {change.previousValue === 0
                           ? "N/A"


### PR DESCRIPTION
This pull request makes a small update to the `NetWorthAreaChart` component to improve privacy handling. When privacy mode is enabled, the absolute change value is now masked with asterisks instead of displaying the actual number.

- Privacy mode enhancement:
  * In `net-worth-area.tsx`, the absolute change value is hidden and replaced with `* * * * * *` when `isPrivacyMode` is true, ensuring sensitive data is not shown.

<img width="1022" height="496" alt="image" src="https://github.com/user-attachments/assets/1b08debb-b642-4af7-98d6-c01655259e3c" />
