### PR TITLE
feat(asset): Let users change symbol ticker from position update form

### DIFF
--- a/components/dashboard/positions/asset/edit-asset-button.tsx
+++ b/components/dashboard/positions/asset/edit-asset-button.tsx
@@ -10,9 +10,10 @@ import type { Position } from "@/types/global.types";
 
 interface Props {
   position: Position;
+  currentSymbolTicker?: string;
 }
 
-export function EditAssetButton({ position }: Props) {
+export function EditAssetButton({ position, currentSymbolTicker }: Props) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -28,6 +29,7 @@ export function EditAssetButton({ position }: Props) {
       </Button>
       <UpdateAssetDialog
         position={position}
+        currentSymbolTicker={currentSymbolTicker}
         open={open}
         onOpenChangeAction={setOpen}
       />

--- a/components/dashboard/positions/asset/header.tsx
+++ b/components/dashboard/positions/asset/header.tsx
@@ -40,7 +40,10 @@ export function AssetHeader({
               <Archive className="size-4" /> Archived
             </Badge>
           )}
-          <EditAssetButton position={position} />
+          <EditAssetButton
+            position={position}
+            currentSymbolTicker={symbol?.ticker}
+          />
           <AssetMoreActionsButton position={position} />
         </div>
       </div>

--- a/components/dashboard/positions/asset/update/index.tsx
+++ b/components/dashboard/positions/asset/update/index.tsx
@@ -14,12 +14,14 @@ import type { Position } from "@/types/global.types";
 
 interface UpdateAssetDialogProps {
   position: Position;
+  currentSymbolTicker?: string;
   open: boolean;
   onOpenChangeAction: (open: boolean) => void;
 }
 
 export function UpdateAssetDialog({
   position,
+  currentSymbolTicker,
   open,
   onOpenChangeAction,
 }: UpdateAssetDialogProps) {
@@ -34,6 +36,7 @@ export function UpdateAssetDialog({
         </DialogHeader>
         <UpdateAssetForm
           position={position}
+          currentSymbolTicker={currentSymbolTicker}
           onSuccess={() => onOpenChangeAction(false)}
         />
       </DialogContent>


### PR DESCRIPTION
- Added currentSymbolTicker prop to EditAssetButton and UpdateAssetForm components for improved symbol management.
- Updated AssetHeader to pass the current symbol ticker to EditAssetButton.
- Integrated an accordion in UpdateAssetForm for advanced options, allowing users to change the ticker symbol with a new UpdateSymbolDialog.
- Refactored UpdateAssetDialog to accommodate the new prop, enhancing the user experience for symbol updates.