### PR TITLE
feat(symbols): Refactor createSymbol function to use createServiceClient for Supabase connection

### DIFF
--- a/server/symbols/create.ts
+++ b/server/symbols/create.ts
@@ -4,10 +4,12 @@ import { getCurrentUser } from "@/server/auth/actions";
 import { fetchYahooFinanceSymbol } from "@/server/symbols/search";
 import { fetchCurrencies } from "@/server/currencies/fetch";
 import { setPrimarySymbolAlias } from "@/server/symbols/resolver";
+import { createServiceClient } from "@/supabase/service";
 
 // Create symbol using Yahoo Finance data
 export async function createSymbol(symbolTicker: string) {
-  const { supabase } = await getCurrentUser();
+  await getCurrentUser();
+  const supabase = createServiceClient();
 
   // 1) Get symbol data from Yahoo Finance
   const yahooFinanceSymbol = await fetchYahooFinanceSymbol(symbolTicker);

--- a/supabase/migrations/20260108102500_harden_rls_service_role_tables.sql
+++ b/supabase/migrations/20260108102500_harden_rls_service_role_tables.sql
@@ -1,0 +1,27 @@
+-- Harden RLS policies for service-role managed tables.
+
+-- Remove overly permissive authenticated write policies.
+DROP POLICY IF EXISTS "Enable insert for all authenticated users"
+  ON public.domain_valuations;
+DROP POLICY IF EXISTS "Enable update for authenticated users"
+  ON public.domain_valuations;
+
+DROP POLICY IF EXISTS "Enable insert for all authenticated users"
+  ON public.quotes;
+DROP POLICY IF EXISTS "  Enable update for authenticated users"
+  ON public.quotes;
+
+DROP POLICY IF EXISTS "Enable insert for all authenticated users"
+  ON public.symbols;
+DROP POLICY IF EXISTS "Enable update for all authenticated users"
+  ON public.symbols;
+
+DROP POLICY IF EXISTS "Enable insert for authenticated users only"
+  ON public.feedback;
+
+-- Allow authenticated users to submit feedback only for themselves.
+CREATE POLICY "Authenticated users can submit feedback"
+  ON public.feedback
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
- Updated the createSymbol function to directly create a Supabase client using createServiceClient instead of retrieving it from getCurrentUser.
- Added a new SQL migration to enhance RLS policies for service-role managed tables, tightening permissions for authenticated users on specific tables.