### PR TITLE
refactor(ai): simplify provider config to openai/gateway env switch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,9 +71,15 @@ SUPABASE_SECRET_KEY=your_supabase_secret_key
 CRON_SECRET=generate_a_strong_random_string
 
 # Optional (used for AI features)
-OPENAI_API_KEY=your_openai_api_key
-AI_CHAT_MODEL=gpt-5-mini / or any other preferred model
-AI_EXTRACTION_MODEL=gpt-5-mini / or any other preferred model
+# Supported providers: openai | gateway
+AI_PROVIDER=openai
+AI_PROVIDER_API_KEY=your_provider_api_key
+AI_CHAT_MODEL_ID=gpt-5-mini
+AI_EXTRACTION_MODEL_ID=gpt-5-mini
+
+# If AI_PROVIDER=gateway, use provider/model IDs:
+# AI_CHAT_MODEL_ID=openai/gpt-5-mini
+# AI_EXTRACTION_MODEL_ID=anthropic/claude-sonnet-4
 
 # Optional (used for domain valuations)
 REPLICATE_API_TOKEN=your_replicate_api_token


### PR DESCRIPTION
Simplifies AI provider configuration to a minimal env-driven contract while keeping flexibility for OSS users and Vercel deployments.

- Adds strict provider switch via `AI_PROVIDER=openai|gateway`
- Uses a single key env: `AI_PROVIDER_API_KEY` (with compatibility fallbacks)
- Renames model envs to `AI_CHAT_MODEL_ID` and `AI_EXTRACTION_MODEL_ID`
- Normalizes model IDs per provider:
  - `openai/gpt-5-mini` works for direct OpenAI (prefix stripped)
  - `gpt-5-mini` works for Gateway (auto-prefixed to `openai/gpt-5-mini`)
- Updates contributor docs with the new env setup and Gateway model examples
- Keeps code intentionally minimal and easy for contributors to extend if they want additional providers