### PR TITLE
perf(market-data): disable live quote repair for range fetches to restore dashboard latency

### DIFF
--- a/server/market-data/sources/symbol-handler.test.ts
+++ b/server/market-data/sources/symbol-handler.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchQuotesMock = vi.fn();
+
+vi.mock("@/server/quotes/fetch", () => ({
+  fetchQuotes: fetchQuotesMock,
+}));
+
+describe("symbolHandler", () => {
+  beforeEach(() => {
+    fetchQuotesMock.mockReset();
+  });
+
+  it("keeps single-date quote fetch behavior unchanged", async () => {
+    const expected = new Map([["sym-1|2026-02-25", 123]]);
+    fetchQuotesMock.mockResolvedValue(expected);
+
+    const { symbolHandler } = await import("./symbol-handler");
+    const result = await symbolHandler.fetchForPositions(
+      [
+        {
+          id: "pos-1",
+          currency: "USD",
+          symbol_id: "sym-1",
+          domain_id: null,
+        },
+      ],
+      new Date("2026-02-25T00:00:00.000Z"),
+      { upsert: true },
+    );
+
+    expect(result).toBe(expected);
+    expect(fetchQuotesMock).toHaveBeenCalledTimes(1);
+    expect(fetchQuotesMock).toHaveBeenCalledWith(
+      [{ symbolLookup: "sym-1", date: new Date("2026-02-25T00:00:00.000Z") }],
+      { upsert: true },
+    );
+  });
+
+  it("disables live miss repair for range requests", async () => {
+    const expected = new Map([["sym-1|2026-02-25", 123]]);
+    fetchQuotesMock.mockResolvedValue(expected);
+
+    const { symbolHandler } = await import("./symbol-handler");
+    expect(symbolHandler.fetchForPositionsRange).toBeTypeOf("function");
+    const result = await symbolHandler.fetchForPositionsRange!(
+      [
+        {
+          id: "pos-1",
+          currency: "USD",
+          symbol_id: "sym-1",
+          domain_id: null,
+        },
+      ],
+      [new Date("2026-02-25T00:00:00.000Z")],
+      { upsert: true },
+    );
+
+    expect(result).toBe(expected);
+    expect(fetchQuotesMock).toHaveBeenCalledTimes(1);
+    expect(fetchQuotesMock).toHaveBeenCalledWith(
+      [{ symbolLookup: "sym-1", date: new Date("2026-02-25T00:00:00.000Z") }],
+      { upsert: true, liveFetchOnMiss: false },
+    );
+  });
+});

--- a/server/market-data/sources/symbol-handler.ts
+++ b/server/market-data/sources/symbol-handler.ts
@@ -65,6 +65,9 @@ export const symbolHandler: MarketDataHandler = {
     try {
       return await fetchQuotes(requests, {
         upsert: options?.upsert,
+        // Range reads must stay fast; avoid blocking response on live provider
+        // repair attempts. Single-date paths still perform read-repair.
+        liveFetchOnMiss: false,
       });
     } catch {
       return new Map();


### PR DESCRIPTION
### Summary
This PR restores dashboard responsiveness by preventing blocking live quote-repair calls during range/history market-data fetches (the main path used by net worth chart history).

### Problem
After recent quote read-repair changes, range requests could trigger live Yahoo fetch attempts on exact cache misses, which added significant latency to:
- `/dashboard` net worth history chart
- some asset detail pages that depend on range/snapshot-heavy valuation paths

### Change
- Updated symbol range handler to call `fetchQuotes(..., { liveFetchOnMiss: false })` for `fetchForPositionsRange`.
- Kept single-date quote fetch behavior unchanged (single-date paths still support live repair).

### Why this approach
- High impact, minimal surface-area change.
- Keeps repair semantics where they matter most for freshness (single-date reads + cron), while removing the largest source of user-visible blocking latency in history/range rendering.

### Tests
Added `server/market-data/sources/symbol-handler.test.ts` covering:
1. Single-date path unchanged.
2. Range path explicitly disables live repair.

Also verified:
- `server/analysis/net-worth/net-worth-history.test.ts`
- `npm run type`

### Scope / Non-goals
- No DB schema changes.
- No cron behavior changes.
- No UI changes.
- Opportunistic async historical repair queue is intentionally out of scope for this PR (planned separately).