### PR TITLE
refactor(dividend-yield): guard projected income against inflated Yahoo trailing dividend amounts

### DIFF
--- a/server/analysis/dividend-yield.ts
+++ b/server/analysis/dividend-yield.ts
@@ -1,17 +1,9 @@
 "use server";
 
-import { addMonths } from "date-fns";
-
 import { fetchDividends } from "@/server/dividends/fetch";
 import { fetchSingleQuote } from "@/server/quotes/fetch";
+import { resolveAnnualDividendAmount } from "@/server/analysis/projected-income/utils";
 import { ensureSymbol } from "@/server/symbols/ensure";
-
-const FREQUENCY_MULTIPLIER: Record<string, number> = {
-  monthly: 12,
-  quarterly: 4,
-  semiannual: 2,
-  annual: 1,
-};
 
 /**
  * Fetch dividend data and compute a dividend yield for a symbol.
@@ -62,38 +54,6 @@ export async function calculateSymbolDividendYield(symbolLookup: string) {
   );
   const latestEvent = sortedEvents[0] ?? null;
 
-  // Prefer Yahoo-provided annual figures when available
-  let annualDividend =
-    (summary.trailing_ttm_dividend ?? 0) > 0
-      ? summary.trailing_ttm_dividend!
-      : (summary.forward_annual_dividend ?? 0);
-
-  // Fall back to the sum of dividends paid in the last year
-  if (annualDividend <= 0 && sortedEvents.length > 0) {
-    const oneYearAgo = addMonths(new Date(), -12);
-    const recentEvents = sortedEvents.filter(
-      (event) => new Date(event.event_date) >= oneYearAgo,
-    );
-    const totalRecent = recentEvents.reduce(
-      (sum, event) => sum + event.gross_amount,
-      0,
-    );
-    if (totalRecent > 0) {
-      annualDividend = totalRecent;
-    }
-  }
-
-  // Last resort: estimate using the most recent payout and inferred frequency
-  if (annualDividend <= 0 && latestEvent) {
-    const frequency = summary.inferred_frequency ?? "";
-    const multiplier = FREQUENCY_MULTIPLIER[frequency] ?? 0;
-    if (multiplier > 0) {
-      annualDividend = latestEvent.gross_amount * multiplier;
-    }
-  }
-
-  const annualDividendRate = annualDividend > 0 ? Number(annualDividend) : null;
-
   const reportedYield =
     summary.dividend_yield && summary.dividend_yield > 0
       ? summary.dividend_yield
@@ -116,6 +76,10 @@ export async function calculateSymbolDividendYield(symbolLookup: string) {
       error,
     );
   }
+
+  const annualDividendRate =
+    resolveAnnualDividendAmount(summary, events, latestPrice ?? undefined) ||
+    null;
 
   if (!reportedYield && annualDividendRate && latestPrice) {
     estimatedYield = annualDividendRate / latestPrice;

--- a/server/analysis/projected-income/portfolio.test.ts
+++ b/server/analysis/projected-income/portfolio.test.ts
@@ -284,6 +284,61 @@ describe("projected income", () => {
     ).toBeCloseTo(5.73, 2);
   });
 
+  it("falls back to the latest historical dividend event when annual fields are unavailable", async () => {
+    const fxDateKey = formatUTCDateKey(new Date());
+    const asOfDateKey = toCivilDateKeyOrThrow("2025-01-15");
+
+    fetchPositionsMock.mockResolvedValue([
+      createPosition({
+        current_quantity: 1,
+        current_unit_value: 100,
+      }),
+    ]);
+
+    fetchDividendsMock.mockResolvedValue(
+      new Map([
+        [
+          "sym-1",
+          {
+            summary: createDividendSummary({
+              trailing_ttm_dividend: null,
+              forward_annual_dividend: null,
+              dividend_yield: null,
+              inferred_frequency: "annual",
+              last_dividend_date: "2023-12-15",
+            }),
+            events: [
+              createDividendEvent({
+                event_date: "2023-12-15",
+                gross_amount: 2,
+              }),
+            ],
+          },
+        ],
+      ]),
+    );
+
+    fetchExchangeRatesMock.mockResolvedValue(
+      new Map([[`USD|${fxDateKey}`, 1]]),
+    );
+
+    const { calculateProjectedIncome } =
+      await import("@/server/analysis/projected-income/portfolio");
+
+    const result = await calculateProjectedIncome(
+      "USD",
+      12,
+      undefined,
+      asOfDateKey,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data?.[11]?.income).toBeCloseTo(2, 6);
+    expect(
+      result.data?.reduce((sum, month) => sum + month.income, 0),
+    ).toBeCloseTo(2, 6);
+  });
+
   it("uses the provided civil as-of date key for FX requests", async () => {
     const asOfDateKey = toCivilDateKeyOrThrow("2025-01-10");
 

--- a/server/analysis/projected-income/portfolio.test.ts
+++ b/server/analysis/projected-income/portfolio.test.ts
@@ -233,6 +233,57 @@ describe("projected income", () => {
     expect(result.data?.[0]?.total).toBeCloseTo(2, 6);
   });
 
+  it("prefers the forward annual dividend when trailing annual dividend is clearly inflated", async () => {
+    const fxDateKey = formatUTCDateKey(new Date());
+    const asOfDateKey = toCivilDateKeyOrThrow("2026-04-10");
+
+    fetchPositionsMock.mockResolvedValue([
+      createPosition({
+        current_quantity: 1,
+        current_unit_value: 211.14,
+      }),
+    ]);
+
+    fetchDividendsMock.mockResolvedValue(
+      new Map([
+        [
+          "sym-1",
+          {
+            summary: createDividendSummary({
+              trailing_ttm_dividend: 95,
+              forward_annual_dividend: 5.73,
+              dividend_yield: 0.0272,
+              inferred_frequency: "semiannual",
+              last_dividend_date: "2025-03-31",
+            }),
+            events: [],
+          },
+        ],
+      ]),
+    );
+
+    fetchExchangeRatesMock.mockResolvedValue(
+      new Map([[`USD|${fxDateKey}`, 1]]),
+    );
+
+    const { calculateProjectedIncome } =
+      await import("@/server/analysis/projected-income/portfolio");
+
+    const result = await calculateProjectedIncome(
+      "USD",
+      12,
+      undefined,
+      asOfDateKey,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data?.[5]?.income).toBeCloseTo(2.865, 3);
+    expect(result.data?.[11]?.income).toBeCloseTo(2.865, 3);
+    expect(
+      result.data?.reduce((sum, month) => sum + month.income, 0),
+    ).toBeCloseTo(5.73, 2);
+  });
+
   it("uses the provided civil as-of date key for FX requests", async () => {
     const asOfDateKey = toCivilDateKeyOrThrow("2025-01-10");
 

--- a/server/analysis/projected-income/symbol.test.ts
+++ b/server/analysis/projected-income/symbol.test.ts
@@ -212,6 +212,57 @@ describe("symbol projected income", () => {
     expect(result.dividendYield).toBe(0.0272);
   });
 
+  it("falls back to the latest historical dividend event when annual fields are unavailable", async () => {
+    const { calculateSymbolProjectedIncomePanelData } =
+      await import("@/server/analysis/projected-income/symbol");
+
+    resolveSymbolInputMock.mockResolvedValue({
+      symbol: { id: "sym-1" },
+    });
+    fetchDividendsMock.mockResolvedValue(
+      new Map([
+        [
+          "sym-1",
+          {
+            summary: createDividendSummary({
+              trailing_ttm_dividend: null,
+              forward_annual_dividend: null,
+              dividend_yield: null,
+              inferred_frequency: "annual",
+              last_dividend_date: "2023-12-15",
+            }),
+            events: [
+              createDividendEvent({
+                event_date: "2023-12-15",
+                gross_amount: 2,
+              }),
+            ],
+          },
+        ],
+      ]),
+    );
+    fetchSingleQuoteMock.mockResolvedValue(100);
+
+    const result = await calculateSymbolProjectedIncomePanelData(
+      "SYM",
+      1,
+      12,
+      undefined,
+      "USD",
+      toCivilDateKeyOrThrow("2025-01-15"),
+    );
+
+    expect(result.projectedIncome.success).toBe(true);
+    expect(result.projectedIncome.data?.[11]?.income).toBeCloseTo(2, 6);
+    expect(
+      result.projectedIncome.data?.reduce(
+        (sum, month) => sum + month.income,
+        0,
+      ),
+    ).toBeCloseTo(2, 6);
+    expect(result.dividendYield).toBeCloseTo(0.02, 6);
+  });
+
   it("returns a deterministic unresolved response when symbol cannot be resolved", async () => {
     const { calculateSymbolProjectedIncomePanelData } =
       await import("@/server/analysis/projected-income/symbol");

--- a/server/analysis/projected-income/symbol.test.ts
+++ b/server/analysis/projected-income/symbol.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+import { toCivilDateKeyOrThrow } from "@/lib/date/date-utils";
+
 import type { Dividend, DividendEvent } from "@/types/global.types";
 
 const fetchDividendsMock = vi.fn();
@@ -162,6 +164,52 @@ describe("symbol projected income", () => {
     expect(result.projectedIncome.success).toBe(true);
     expect(result.dividendYield).toBeCloseTo(0.02, 6);
     expect(fetchSingleQuoteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers the forward annual dividend when trailing annual dividend is clearly inflated", async () => {
+    const { calculateSymbolProjectedIncomePanelData } =
+      await import("@/server/analysis/projected-income/symbol");
+
+    resolveSymbolInputMock.mockResolvedValue({
+      symbol: { id: "sym-1" },
+    });
+    fetchDividendsMock.mockResolvedValue(
+      new Map([
+        [
+          "sym-1",
+          {
+            summary: createDividendSummary({
+              trailing_ttm_dividend: 95,
+              forward_annual_dividend: 5.73,
+              dividend_yield: 0.0272,
+              inferred_frequency: "semiannual",
+              last_dividend_date: "2025-03-31",
+            }),
+            events: [],
+          },
+        ],
+      ]),
+    );
+
+    const result = await calculateSymbolProjectedIncomePanelData(
+      "TM",
+      1,
+      12,
+      211.14,
+      "USD",
+      toCivilDateKeyOrThrow("2026-04-10"),
+    );
+
+    expect(result.projectedIncome.success).toBe(true);
+    expect(result.projectedIncome.data?.[5]?.income).toBeCloseTo(2.865, 3);
+    expect(result.projectedIncome.data?.[11]?.income).toBeCloseTo(2.865, 3);
+    expect(
+      result.projectedIncome.data?.reduce(
+        (sum, month) => sum + month.income,
+        0,
+      ),
+    ).toBeCloseTo(5.73, 2);
+    expect(result.dividendYield).toBe(0.0272);
   });
 
   it("returns a deterministic unresolved response when symbol cannot be resolved", async () => {

--- a/server/analysis/projected-income/symbol.ts
+++ b/server/analysis/projected-income/symbol.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { addMonths } from "date-fns";
-
 import { fetchDividends } from "@/server/dividends/fetch";
 import { fetchSingleQuote } from "@/server/quotes/fetch";
 import { resolveSymbolInput } from "@/server/symbols/resolve";
@@ -11,6 +9,7 @@ import {
   buildDividendProjectionBasis,
   calculateMonthlyDividend,
   formatUTCMonthKey,
+  resolveAnnualDividendAmount,
 } from "@/server/analysis/projected-income/utils";
 import {
   parseLocalDateKey,
@@ -41,13 +40,6 @@ export interface SymbolProjectedIncomePanelResult {
   projectedIncome: SymbolProjectedIncomeResult;
   dividendYield: number | null;
 }
-
-const DIVIDEND_FREQUENCY_MULTIPLIER: Record<string, number> = {
-  monthly: 12,
-  quarterly: 4,
-  semiannual: 2,
-  annual: 1,
-};
 
 async function fetchSymbolDividendContext(
   symbolLookup: string,
@@ -138,49 +130,6 @@ function buildProjectedIncomeResultFromDividendContext({
   };
 }
 
-function computeAnnualDividendRate({
-  summary,
-  events,
-}: {
-  summary: Dividend;
-  events: DividendEvent[];
-}): number | null {
-  const sortedEvents = [...events].sort(
-    (a, b) =>
-      new Date(b.event_date).getTime() - new Date(a.event_date).getTime(),
-  );
-  const latestEvent = sortedEvents[0] ?? null;
-
-  let annualDividend =
-    (summary.trailing_ttm_dividend ?? 0) > 0
-      ? summary.trailing_ttm_dividend!
-      : (summary.forward_annual_dividend ?? 0);
-
-  if (annualDividend <= 0 && sortedEvents.length > 0) {
-    const oneYearAgo = addMonths(new Date(), -12);
-    const recentEvents = sortedEvents.filter(
-      (event) => new Date(event.event_date) >= oneYearAgo,
-    );
-    const totalRecent = recentEvents.reduce(
-      (sum, event) => sum + event.gross_amount,
-      0,
-    );
-    if (totalRecent > 0) {
-      annualDividend = totalRecent;
-    }
-  }
-
-  if (annualDividend <= 0 && latestEvent) {
-    const frequency = summary.inferred_frequency ?? "";
-    const multiplier = DIVIDEND_FREQUENCY_MULTIPLIER[frequency] ?? 0;
-    if (multiplier > 0) {
-      annualDividend = latestEvent.gross_amount * multiplier;
-    }
-  }
-
-  return annualDividend > 0 ? annualDividend : null;
-}
-
 async function resolvePriceForYield(
   canonicalId: string,
   unitValue?: number,
@@ -231,7 +180,11 @@ async function computeDividendYieldFromDividendContext({
     return reportedYield;
   }
 
-  const annualDividendRate = computeAnnualDividendRate({ summary, events });
+  const annualDividendRate = resolveAnnualDividendAmount(
+    summary,
+    events,
+    unitValue,
+  );
   if (!annualDividendRate) {
     return null;
   }

--- a/server/analysis/projected-income/utils.ts
+++ b/server/analysis/projected-income/utils.ts
@@ -150,6 +150,13 @@ const DIVIDEND_AMOUNT_TOLERANCE_RATIO = 0.1;
 // Two times the smaller reference amount is a strong enough signal to catch
 // cross-basis mismatches like TM without rejecting normal provider variance.
 const CLEAR_INFLATION_MULTIPLIER = 2;
+const ANNUAL_DIVIDEND_MULTIPLIER_BY_INFERRED_FREQUENCY: Record<string, number> =
+  {
+    monthly: 12,
+    quarterly: 4,
+    semiannual: 2,
+    annual: 1,
+  };
 
 export function resolveAnnualDividendAmount(
   summary: Dividend,
@@ -224,6 +231,13 @@ export function resolveAnnualDividendAmount(
     return annualAmountImpliedByYield;
   }
 
+  const annualAmountFromLatestHistoricalEvent =
+    resolveAnnualDividendAmountFromLatestHistoricalEvent(summary, events);
+
+  if (annualAmountFromLatestHistoricalEvent > 0) {
+    return annualAmountFromLatestHistoricalEvent;
+  }
+
   return 0;
 }
 
@@ -239,6 +253,29 @@ function resolveAnnualDividendAmountFromYield(
   }
 
   return yieldRate * currentUnitValue;
+}
+
+function resolveAnnualDividendAmountFromLatestHistoricalEvent(
+  summary: Dividend,
+  events: DividendEvent[],
+): number {
+  // Low-confidence fallback for sparse histories: reuse the latest observed
+  // payout only when we also have an inferred payment cadence.
+  const latestDividendEvent = getLatestDividendEvent(events);
+  if (!latestDividendEvent) {
+    return 0;
+  }
+
+  const annualDividendMultiplier =
+    ANNUAL_DIVIDEND_MULTIPLIER_BY_INFERRED_FREQUENCY[
+      summary.inferred_frequency ?? ""
+    ] ?? 0;
+
+  if (annualDividendMultiplier <= 0) {
+    return 0;
+  }
+
+  return latestDividendEvent.gross_amount * annualDividendMultiplier;
 }
 
 function areAmountsWithinTolerance(leftAmount: number, rightAmount: number) {

--- a/server/analysis/projected-income/utils.ts
+++ b/server/analysis/projected-income/utils.ts
@@ -146,12 +146,18 @@ export function buildDividendProjectionBasis(
   };
 }
 
-function resolveAnnualDividendAmount(
+const DIVIDEND_AMOUNT_TOLERANCE_RATIO = 0.1;
+// Two times the smaller reference amount is a strong enough signal to catch
+// cross-basis mismatches like TM without rejecting normal provider variance.
+const CLEAR_INFLATION_MULTIPLIER = 2;
+
+export function resolveAnnualDividendAmount(
   summary: Dividend,
   events: DividendEvent[],
   currentUnitValue?: number,
 ): number {
-  // Prefer provider amounts unless they are clearly inflated compared to payouts we observed.
+  // Prefer provider amounts unless other data points clearly show that the
+  // trailing annual amount is on a different basis than the current listing.
   const oneYearAgo = new Date();
   oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
 
@@ -159,40 +165,94 @@ function resolveAnnualDividendAmount(
     (event) => new Date(event.event_date) >= oneYearAgo,
   );
 
-  const eventAnnualAmount =
+  const annualAmountFromRecentEvents =
     recentEvents.length > 0
       ? recentEvents.reduce((sum, event) => sum + event.gross_amount, 0)
       : 0;
 
-  const providerTtm = summary.trailing_ttm_dividend || 0;
-  const providerForward = summary.forward_annual_dividend || 0;
+  const providerTrailingAnnualDividend = summary.trailing_ttm_dividend || 0;
+  const providerForwardAnnualDividend = summary.forward_annual_dividend || 0;
+  const annualAmountImpliedByYield = resolveAnnualDividendAmountFromYield(
+    summary,
+    currentUnitValue,
+  );
 
-  const hasEvents = eventAnnualAmount > 0;
-  const ttmWithinTolerance =
-    providerTtm > 0 && hasEvents
-      ? providerTtm >= eventAnnualAmount * 0.9 &&
-        providerTtm <= eventAnnualAmount * 1.1
-      : true;
+  const hasRecentEventAnnualAmount = annualAmountFromRecentEvents > 0;
+  const trailingAnnualDividendMatchesRecentEvents =
+    providerTrailingAnnualDividend > 0 && hasRecentEventAnnualAmount
+      ? areAmountsWithinTolerance(
+          providerTrailingAnnualDividend,
+          annualAmountFromRecentEvents,
+        )
+      : false;
 
-  // Keep TTM when it aligns with payouts (±10%); otherwise prefer events, then forward.
-  let annualAmount =
-    providerTtm > 0 && ttmWithinTolerance
-      ? providerTtm
-      : hasEvents
-        ? eventAnnualAmount
-        : providerForward > 0
-          ? providerForward
-          : providerTtm;
-
-  if (annualAmount <= 0) {
-    // Yahoo dividend_yield is an annual rate (decimal, e.g. 0.04 = 4%).
-    const yieldRate = summary.dividend_yield ?? 0;
-    if (yieldRate > 0 && currentUnitValue && currentUnitValue > 0) {
-      annualAmount = yieldRate * currentUnitValue;
-    }
+  if (trailingAnnualDividendMatchesRecentEvents) {
+    return providerTrailingAnnualDividend;
   }
 
-  return annualAmount > 0 ? annualAmount : 0;
+  if (hasRecentEventAnnualAmount) {
+    return annualAmountFromRecentEvents;
+  }
+
+  const referenceAnnualAmounts = [
+    providerForwardAnnualDividend,
+    annualAmountImpliedByYield,
+  ].filter((amount) => amount > 0);
+
+  const trailingAnnualDividendLooksClearlyInflated =
+    providerTrailingAnnualDividend > 0 &&
+    referenceAnnualAmounts.length > 0 &&
+    referenceAnnualAmounts.every((referenceAnnualAmount) =>
+      isAmountClearlyInflated(
+        providerTrailingAnnualDividend,
+        referenceAnnualAmount,
+      ),
+    );
+
+  if (
+    providerTrailingAnnualDividend > 0 &&
+    !trailingAnnualDividendLooksClearlyInflated
+  ) {
+    return providerTrailingAnnualDividend;
+  }
+
+  if (providerForwardAnnualDividend > 0) {
+    return providerForwardAnnualDividend;
+  }
+
+  if (annualAmountImpliedByYield > 0) {
+    return annualAmountImpliedByYield;
+  }
+
+  return 0;
+}
+
+function resolveAnnualDividendAmountFromYield(
+  summary: Dividend,
+  currentUnitValue?: number,
+): number {
+  // Yahoo dividend_yield is an annual rate (decimal, e.g. 0.04 = 4%).
+  const yieldRate = summary.dividend_yield ?? 0;
+
+  if (yieldRate <= 0 || !currentUnitValue || currentUnitValue <= 0) {
+    return 0;
+  }
+
+  return yieldRate * currentUnitValue;
+}
+
+function areAmountsWithinTolerance(leftAmount: number, rightAmount: number) {
+  return (
+    leftAmount >= rightAmount * (1 - DIVIDEND_AMOUNT_TOLERANCE_RATIO) &&
+    leftAmount <= rightAmount * (1 + DIVIDEND_AMOUNT_TOLERANCE_RATIO)
+  );
+}
+
+function isAmountClearlyInflated(
+  candidateAmount: number,
+  referenceAmount: number,
+) {
+  return candidateAmount > referenceAmount * CLEAR_INFLATION_MULTIPLIER;
 }
 
 function resolveLastPaymentMonth(


### PR DESCRIPTION
## Summary

Fix projected dividend income for symbols where Yahoo's trailing annual dividend appears to be on the wrong basis for the current listing.

This was causing incorrect projected income for `TM` on NYSE:
- dividend yield looked reasonable
- projected annual income was inflated to `USD 95.00` for 1 share

## Root Cause

Our projected income logic trusted Yahoo `trailingAnnualDividendRate` unless recent dividend events disproved it.

For some foreign / ADR symbols, Yahoo can return a trailing annual dividend that does not match the listing basis used by:
- the forward annual dividend
- the reported dividend yield
- the recent payout events

In `TM`, Yahoo returned:
- forward annual dividend: `5.73`
- dividend yield: about `2.72%`
- trailing annual dividend: `95`

The `95` value was being treated as a valid annual per-share amount and projected into the chart.

## What Changed

- Centralized the annual dividend amount selection logic in the shared projected income utility.
- Kept the existing safety behavior that prefers recent payout events when trailing annual dividend is inconsistent with actual payouts.
- Added a second guard for cases with no recent usable events:
  - compare trailing annual dividend against
    - forward annual dividend
    - yield-implied annual dividend
  - reject trailing annual dividend when it is clearly inflated relative to both references
- Reused the same annual amount selection logic in the dividend yield analysis path so the fallback behavior stays consistent.

## Result

For `TM`, projected income now uses the sane annual dividend basis and no longer shows `USD 95.00` for 1 share.

## Tests

Added regression coverage for the `TM`-style mismatch in:
- symbol projected income
- portfolio projected income

Verified with:

`npx vitest run server/analysis/projected-income/symbol.test.ts server/analysis/projected-income/portfolio.test.ts`
