### PR TITLE
Email cron optimization

### DIFF
--- a/app/(public)/unsubscribe/page.tsx
+++ b/app/(public)/unsubscribe/page.tsx
@@ -28,18 +28,20 @@ function UnsubscribeCard({
   ctaHref: string;
 }) {
   return (
-    <Card className="mx-auto my-8 max-w-xl">
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
-      </CardHeader>
+    <div className="mx-auto my-8 max-w-xl p-3">
+      <Card className="rounded-lg shadow-xs">
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
 
-      <CardFooter>
-        <Button asChild>
-          <Link href={ctaHref}>{ctaLabel}</Link>
-        </Button>
-      </CardFooter>
-    </Card>
+        <CardFooter>
+          <Button asChild>
+            <Link href={ctaHref}>{ctaLabel}</Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8094,9 +8094,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -9769,9 +9769,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.25",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
-      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -19408,9 +19408,9 @@
       }
     },
     "node_modules/rettime": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.8.tgz",
-      "integrity": "sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
       "license": "MIT"
     },
     "node_modules/reusify": {
@@ -20715,9 +20715,9 @@
       "license": "MIT"
     },
     "node_modules/supabase": {
-      "version": "2.98.0",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.98.0.tgz",
-      "integrity": "sha512-1r56wzoi6SFj+i0XHqF9rSLrjaBSrs+t6xUWn3I+UVnO9nb5ITkmaLEeGgjf7naiBUDf9rtqyRoI+5hTrezZNg==",
+      "version": "2.98.1",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.98.1.tgz",
+      "integrity": "sha512-hnPNVjqi8BClWd73YzSzdokap2o+JtCcx6oOOB2qV34CIwXip6IToeQMhdkblFJFGDwixRdqYEj590qB4D5+Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -22514,9 +22514,9 @@
       }
     },
     "node_modules/yocto-spinner": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.1.0.tgz",
-      "integrity": "sha512-/BY0AUXnS7IKO354uLLA2eRcWiqDifEbd6unXCsOxkFDAkhgUL3PH9X2bFoaU0YchnDXsF+iKleeTLJGckbXfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.0.tgz",
+      "integrity": "sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==",
       "license": "MIT",
       "dependencies": {
         "yoctocolors": "^2.1.1"
@@ -22541,9 +22541,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
-      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/server/ai/tools/top-movers.test.ts
+++ b/server/ai/tools/top-movers.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getTopMovers } from "@/server/ai/tools/top-movers";
+
+const { getAssetsPerformanceMock } = vi.hoisted(() => ({
+  getAssetsPerformanceMock: vi.fn(),
+}));
+
+vi.mock("@/server/ai/tools/assets-performance", () => ({
+  getAssetsPerformance: getAssetsPerformanceMock,
+}));
+
+interface FakeAssetInput {
+  id: string;
+  symbol: string;
+  priceReturnPct: number;
+  valueChangeAbs: number;
+}
+
+function createFakeAsset({
+  id,
+  symbol,
+  priceReturnPct,
+  valueChangeAbs,
+}: FakeAssetInput) {
+  return {
+    asset: {
+      id,
+      name: `${symbol} Inc.`,
+      symbol,
+      category: "stock",
+      currency: "USD",
+      isArchived: false,
+    },
+    period: {
+      startDate: "2026-04-27",
+      endDate: "2026-05-04",
+      baseCurrency: "USD",
+      partialPeriod: false,
+    },
+    price: { start: 100, end: 100, startBase: 100, endBase: 100 },
+    quantity: { start: 1, end: 1 },
+    value: { startBase: 100, endBase: 100 },
+    performance: {
+      priceReturnPct,
+      valueChangeAbs,
+      valueChangePct: priceReturnPct,
+    },
+    unrealized: { totalCostBasis: 100, profitLoss: 0, profitLossPct: 0 },
+  };
+}
+
+function mockPerfWithAssets(assets: FakeAssetInput[]) {
+  getAssetsPerformanceMock.mockResolvedValue({
+    period: {
+      startDate: "2026-04-27",
+      endDate: "2026-05-04",
+      daysCount: 7,
+      baseCurrency: "USD",
+    },
+    assets: assets.map(createFakeAsset),
+  });
+}
+
+describe("getTopMovers", () => {
+  beforeEach(() => {
+    getAssetsPerformanceMock.mockReset();
+  });
+
+  it("never lists the same asset as both a gainer and a loser when assets <= limit", async () => {
+    mockPerfWithAssets([
+      { id: "p-1", symbol: "BITF", priceReturnPct: -1.6, valueChangeAbs: -25 },
+      {
+        id: "p-2",
+        symbol: "MSFT",
+        priceReturnPct: -2.4,
+        valueChangeAbs: -41.52,
+      },
+      {
+        id: "p-3",
+        symbol: "SOFI",
+        priceReturnPct: -12.4,
+        valueChangeAbs: -233,
+      },
+    ]);
+
+    const result = await getTopMovers({
+      baseCurrency: "USD",
+      startDate: "2026-04-27",
+      endDate: "2026-05-04",
+      limit: 3,
+    });
+
+    expect(result.topByPct.gainers).toEqual([]);
+    expect(result.topByPct.losers.map((l) => l.asset.id)).toEqual([
+      "p-3",
+      "p-2",
+      "p-1",
+    ]);
+    expect(result.topByAbs.gainers).toEqual([]);
+    expect(result.topByAbs.losers.map((l) => l.asset.id)).toEqual([
+      "p-3",
+      "p-2",
+      "p-1",
+    ]);
+  });
+
+  it("returns a single gainer with no losers when the portfolio has one positive asset", async () => {
+    mockPerfWithAssets([
+      {
+        id: "p-1",
+        symbol: "XDWS.SW",
+        priceReturnPct: 0.4,
+        valueChangeAbs: 23.13,
+      },
+    ]);
+
+    const result = await getTopMovers({
+      baseCurrency: "USD",
+      startDate: "2026-04-27",
+      endDate: "2026-05-04",
+      limit: 3,
+    });
+
+    expect(result.topByPct.gainers.map((g) => g.asset.id)).toEqual(["p-1"]);
+    expect(result.topByPct.losers).toEqual([]);
+    expect(result.topByAbs.gainers.map((g) => g.asset.id)).toEqual(["p-1"]);
+    expect(result.topByAbs.losers).toEqual([]);
+  });
+
+  it("excludes flat assets from both gainer and loser lists", async () => {
+    mockPerfWithAssets([
+      { id: "p-up", symbol: "AAA", priceReturnPct: 5, valueChangeAbs: 50 },
+      { id: "p-flat", symbol: "BBB", priceReturnPct: 0, valueChangeAbs: 0 },
+      { id: "p-down", symbol: "CCC", priceReturnPct: -3, valueChangeAbs: -30 },
+    ]);
+
+    const result = await getTopMovers({
+      baseCurrency: "USD",
+      startDate: "2026-04-27",
+      endDate: "2026-05-04",
+      limit: 5,
+    });
+
+    expect(result.topByPct.gainers.map((g) => g.asset.id)).toEqual(["p-up"]);
+    expect(result.topByPct.losers.map((l) => l.asset.id)).toEqual(["p-down"]);
+    expect(result.topByAbs.gainers.map((g) => g.asset.id)).toEqual(["p-up"]);
+    expect(result.topByAbs.losers.map((l) => l.asset.id)).toEqual(["p-down"]);
+  });
+
+  it("orders gainers descending and losers most-negative first, capping at limit", async () => {
+    mockPerfWithAssets([
+      { id: "g-1", symbol: "GA", priceReturnPct: 12, valueChangeAbs: 120 },
+      { id: "g-2", symbol: "GB", priceReturnPct: 8, valueChangeAbs: 80 },
+      { id: "g-3", symbol: "GC", priceReturnPct: 4, valueChangeAbs: 40 },
+      { id: "g-4", symbol: "GD", priceReturnPct: 1, valueChangeAbs: 10 },
+      { id: "l-1", symbol: "LA", priceReturnPct: -3, valueChangeAbs: -30 },
+      { id: "l-2", symbol: "LB", priceReturnPct: -7, valueChangeAbs: -70 },
+      { id: "l-3", symbol: "LC", priceReturnPct: -11, valueChangeAbs: -110 },
+      { id: "l-4", symbol: "LD", priceReturnPct: -15, valueChangeAbs: -150 },
+    ]);
+
+    const result = await getTopMovers({
+      baseCurrency: "USD",
+      startDate: "2026-04-27",
+      endDate: "2026-05-04",
+      limit: 3,
+    });
+
+    expect(result.topByPct.gainers.map((g) => g.asset.id)).toEqual([
+      "g-1",
+      "g-2",
+      "g-3",
+    ]);
+    expect(result.topByPct.losers.map((l) => l.asset.id)).toEqual([
+      "l-4",
+      "l-3",
+      "l-2",
+    ]);
+    expect(result.topByAbs.gainers.map((g) => g.asset.id)).toEqual([
+      "g-1",
+      "g-2",
+      "g-3",
+    ]);
+    expect(result.topByAbs.losers.map((l) => l.asset.id)).toEqual([
+      "l-4",
+      "l-3",
+      "l-2",
+    ]);
+  });
+});

--- a/server/ai/tools/top-movers.test.ts
+++ b/server/ai/tools/top-movers.test.ts
@@ -148,6 +148,48 @@ describe("getTopMovers", () => {
     expect(result.topByAbs.losers.map((l) => l.asset.id)).toEqual(["p-down"]);
   });
 
+  it("returns empty lists for non-positive or fractional limits", async () => {
+    mockPerfWithAssets([
+      { id: "g-1", symbol: "GA", priceReturnPct: 5, valueChangeAbs: 50 },
+      { id: "l-1", symbol: "LA", priceReturnPct: -5, valueChangeAbs: -50 },
+      { id: "l-2", symbol: "LB", priceReturnPct: -10, valueChangeAbs: -100 },
+    ]);
+
+    for (const limitInput of [0, -3, 0.4]) {
+      const result = await getTopMovers({
+        baseCurrency: "USD",
+        startDate: "2026-04-27",
+        endDate: "2026-05-04",
+        limit: limitInput,
+      });
+
+      expect(result.topByPct.gainers).toEqual([]);
+      expect(result.topByPct.losers).toEqual([]);
+      expect(result.topByAbs.gainers).toEqual([]);
+      expect(result.topByAbs.losers).toEqual([]);
+    }
+  });
+
+  it("truncates fractional limits before slicing", async () => {
+    mockPerfWithAssets([
+      { id: "g-1", symbol: "GA", priceReturnPct: 12, valueChangeAbs: 120 },
+      { id: "g-2", symbol: "GB", priceReturnPct: 8, valueChangeAbs: 80 },
+      { id: "g-3", symbol: "GC", priceReturnPct: 4, valueChangeAbs: 40 },
+    ]);
+
+    const result = await getTopMovers({
+      baseCurrency: "USD",
+      startDate: "2026-04-27",
+      endDate: "2026-05-04",
+      limit: 2.9,
+    });
+
+    expect(result.topByPct.gainers.map((g) => g.asset.id)).toEqual([
+      "g-1",
+      "g-2",
+    ]);
+  });
+
   it("orders gainers descending and losers most-negative first, capping at limit", async () => {
     mockPerfWithAssets([
       { id: "g-1", symbol: "GA", priceReturnPct: 12, valueChangeAbs: 120 },

--- a/server/ai/tools/top-movers.ts
+++ b/server/ai/tools/top-movers.ts
@@ -15,7 +15,9 @@ interface GetTopMoversParams {
 }
 
 export async function getTopMovers(params: GetTopMoversParams) {
-  const limit = params.limit ?? 5;
+  // Clamp to a non-negative integer so callers passing 0, a negative value,
+  // or a fractional limit can't trigger `slice(-0)` returning every asset.
+  const limit = Math.max(0, Math.trunc(params.limit ?? 5));
 
   const perf = await getAssetsPerformance({
     baseCurrency: params.baseCurrency,
@@ -48,14 +50,16 @@ export async function getTopMovers(params: GetTopMoversParams) {
   // Filter by sign before slicing so gainers and losers never overlap and
   // never include flat or wrong-sign assets, even when the portfolio has
   // fewer than `limit` assets or all assets moved the same direction.
+  // Losers reverse the sort first so a `limit` of 0 still produces an empty
+  // list (avoiding the `slice(-0)` "return everything" trap).
   const gainersByPct = byPct
     .filter((a) => a.performance.priceReturnPct > 0)
     .slice(0, limit)
     .map(mapItem);
   const losersByPct = byPct
     .filter((a) => a.performance.priceReturnPct < 0)
-    .slice(-limit)
     .reverse()
+    .slice(0, limit)
     .map(mapItem);
 
   const gainersByAbs = byAbs
@@ -64,8 +68,8 @@ export async function getTopMovers(params: GetTopMoversParams) {
     .map(mapItem);
   const losersByAbs = byAbs
     .filter((a) => a.performance.valueChangeAbs < 0)
-    .slice(-limit)
     .reverse()
+    .slice(0, limit)
     .map(mapItem);
 
   const partialCount = assets.reduce(

--- a/server/ai/tools/top-movers.ts
+++ b/server/ai/tools/top-movers.ts
@@ -45,11 +45,28 @@ export async function getTopMovers(params: GetTopMoversParams) {
     partialPeriod: a.period.partialPeriod,
   });
 
-  const gainersByPct = byPct.slice(0, limit).map(mapItem);
-  const losersByPct = byPct.slice(-limit).reverse().map(mapItem);
+  // Filter by sign before slicing so gainers and losers never overlap and
+  // never include flat or wrong-sign assets, even when the portfolio has
+  // fewer than `limit` assets or all assets moved the same direction.
+  const gainersByPct = byPct
+    .filter((a) => a.performance.priceReturnPct > 0)
+    .slice(0, limit)
+    .map(mapItem);
+  const losersByPct = byPct
+    .filter((a) => a.performance.priceReturnPct < 0)
+    .slice(-limit)
+    .reverse()
+    .map(mapItem);
 
-  const gainersByAbs = byAbs.slice(0, limit).map(mapItem);
-  const losersByAbs = byAbs.slice(-limit).reverse().map(mapItem);
+  const gainersByAbs = byAbs
+    .filter((a) => a.performance.valueChangeAbs > 0)
+    .slice(0, limit)
+    .map(mapItem);
+  const losersByAbs = byAbs
+    .filter((a) => a.performance.valueChangeAbs < 0)
+    .slice(-limit)
+    .reverse()
+    .map(mapItem);
 
   const partialCount = assets.reduce(
     (acc, a) => acc + (a.period.partialPeriod ? 1 : 0),

--- a/server/analysis/dividend-yield.ts
+++ b/server/analysis/dividend-yield.ts
@@ -24,8 +24,11 @@ export async function calculateSymbolDividendYield(symbolLookup: string) {
   const displayTicker =
     ensuredSymbol.primaryAlias?.value ?? ensuredSymbol.symbol.ticker ?? input;
 
-  // 2) Attempt to reuse cached dividend data when available
-  const dividendsMap = await fetchDividends([{ symbolId: canonicalId }], false);
+  // 2) Reuse cached dividend data when present, but do not seed the cache from
+  // an on-demand yield probe.
+  const dividendsMap = await fetchDividends([{ symbolId: canonicalId }], {
+    upsert: false,
+  });
   const entry = dividendsMap.get(canonicalId);
 
   if (!entry || !entry.summary || entry.summary.pays_dividends === false) {

--- a/server/analysis/projected-income/portfolio.test.ts
+++ b/server/analysis/projected-income/portfolio.test.ts
@@ -375,4 +375,36 @@ describe("projected income", () => {
       ),
     ).toBe(true);
   });
+
+  it("passes dividend fetch options and returns empty data when cache has no dividend basis", async () => {
+    const asOfDateKey = toCivilDateKeyOrThrow("2025-01-15");
+
+    fetchPositionsMock.mockResolvedValue([createPosition()]);
+    fetchDividendsMock.mockResolvedValue(new Map());
+
+    const { calculateProjectedIncome } =
+      await import("@/server/analysis/projected-income/portfolio");
+
+    const result = await calculateProjectedIncome(
+      "USD",
+      1,
+      undefined,
+      asOfDateKey,
+      {
+        dividendFetch: {
+          refreshMissing: false,
+        },
+      },
+    );
+
+    expect(fetchDividendsMock).toHaveBeenCalledWith([{ symbolId: "sym-1" }], {
+      refreshMissing: false,
+    });
+    expect(fetchExchangeRatesMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: true,
+      data: [],
+      message: "No dividend-paying positions found in your portfolio",
+    });
+  });
 });

--- a/server/analysis/projected-income/portfolio.ts
+++ b/server/analysis/projected-income/portfolio.ts
@@ -3,7 +3,10 @@
 import { cache } from "react";
 
 import { fetchPositions } from "@/server/positions/fetch";
-import { fetchDividends } from "@/server/dividends/fetch";
+import {
+  fetchDividends,
+  type FetchDividendsOptions,
+} from "@/server/dividends/fetch";
 import { fetchExchangeRates } from "@/server/exchange-rates/fetch";
 
 import { convertCurrency } from "@/lib/currency-conversion";
@@ -36,6 +39,10 @@ export interface ProjectedIncomeResult {
   data?: ProjectedIncomeData[];
   message?: string;
   currency?: string;
+}
+
+export interface ProjectedIncomeOptions {
+  dividendFetch?: FetchDividendsOptions;
 }
 
 export interface ProjectedIncomeStackedSeries {
@@ -163,6 +170,7 @@ export const calculateProjectedIncome = cache(
     monthsAhead: number = 12,
     context?: PositionsQueryContext,
     asOfDateKey?: CivilDateKey,
+    options: ProjectedIncomeOptions = {},
   ) => {
     try {
       // 1. Resolve analysis day in civil-date semantics.
@@ -195,6 +203,7 @@ export const calculateProjectedIncome = cache(
 
       const dividendsMap = await fetchDividends(
         symbolIds.map((symbolId) => ({ symbolId })),
+        options.dividendFetch,
       );
 
       const projectionBasisBySymbolId = buildProjectionBasisBySymbolId(

--- a/server/automated-emails/digest.test.ts
+++ b/server/automated-emails/digest.test.ts
@@ -117,6 +117,11 @@ describe("buildAutomatedEmailDigest", () => {
       2,
       undefined,
       "2026-04-17",
+      {
+        dividendFetch: {
+          refreshMissing: false,
+        },
+      },
     );
 
     expect(result).toMatchObject({

--- a/server/automated-emails/digest.ts
+++ b/server/automated-emails/digest.ts
@@ -188,11 +188,18 @@ export async function buildAutomatedEmailDigest(
         todayDateKey: asOfDateKey,
         positionsQueryContext: input.positionsQueryContext,
       }),
+      // Cron path: never block email sending on Yahoo dividend refreshes.
+      // Projected income is omitted when the cache has no dividend basis.
       calculateProjectedIncome(
         input.profile.display_currency,
         projectedIncomeMonthsAhead,
         input.positionsQueryContext,
         asOfDateKey,
+        {
+          dividendFetch: {
+            refreshMissing: false,
+          },
+        },
       ),
     ]);
 

--- a/server/automated-emails/run.test.ts
+++ b/server/automated-emails/run.test.ts
@@ -116,6 +116,26 @@ function clearAutomatedEmailEnvVars() {
   delete process.env.NEXT_PUBLIC_SITE_URL;
 }
 
+function expectCronTimings(stats: {
+  timingsMs?: {
+    total: unknown;
+    loadCandidates: unknown;
+    scheduleEvaluation: unknown;
+    recipientLookup: unknown;
+    digestAndTemplatePreparation: unknown;
+    providerSend: unknown;
+  };
+}) {
+  expect(stats.timingsMs).toEqual({
+    total: expect.any(Number),
+    loadCandidates: expect.any(Number),
+    scheduleEvaluation: expect.any(Number),
+    recipientLookup: expect.any(Number),
+    digestAndTemplatePreparation: expect.any(Number),
+    providerSend: expect.any(Number),
+  });
+}
+
 describe("runAutomatedEmailCron", () => {
   beforeEach(() => {
     clearAutomatedEmailEnvVars();
@@ -155,6 +175,7 @@ describe("runAutomatedEmailCron", () => {
     expect(result.message).toBe("Automated emails are disabled");
     expect(result.stats.enabled).toBe(false);
     expect(result.stats.scannedUsers).toBe(0);
+    expectCronTimings(result.stats);
     expect(createServiceClientMock).not.toHaveBeenCalled();
     expect(sendAutomatedEmailMock).not.toHaveBeenCalled();
   });
@@ -180,8 +201,53 @@ describe("runAutomatedEmailCron", () => {
         "NEXT_PUBLIC_SITE_URL",
       ]),
     );
+    expectCronTimings(result.stats);
     expect(createServiceClientMock).not.toHaveBeenCalled();
     expect(sendAutomatedEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("returns timing stats when no users are due", async () => {
+    setRequiredAutomatedEmailEnvVars();
+
+    createServiceClientMock.mockReturnValue(
+      createFakeServiceClient({
+        candidateRows: [
+          {
+            user_id: "user-not-due",
+            weekly_recap_enabled: true,
+            marketing_emails_enabled: true,
+            profiles: {
+              user_id: "user-not-due",
+              username: "Not Due",
+              display_currency: "USD",
+              time_zone: "America/New_York",
+              last_app_activity_at: null,
+            },
+          },
+        ],
+        recentReengagementRows: [],
+      }),
+    );
+    evaluateAutomatedEmailScheduleMock.mockReturnValue({
+      weeklyRecapDue: false,
+      reengagementDue: false,
+      selectedEmailType: null,
+      deliveryKey: null,
+      localDateKey: "2026-04-20",
+      localHour: 13,
+    });
+
+    const { runAutomatedEmailCron } = await import("./run");
+    const result = await runAutomatedEmailCron(
+      new Date("2026-04-20T13:00:00.000Z"),
+    );
+
+    expect(result.message).toBe("No automated emails were due");
+    expect(result.stats.scannedUsers).toBe(1);
+    expect(result.stats.dueUsers).toBe(0);
+    expectCronTimings(result.stats);
+    expect(fetchRecipientEmailsByUserIdMock).not.toHaveBeenCalled();
+    expect(sendAutomatedEmailBatchMock).not.toHaveBeenCalled();
   });
 
   it("sends a weekly recap and short-circuits already-sent users before building the digest", async () => {
@@ -327,6 +393,7 @@ describe("runAutomatedEmailCron", () => {
     expect(result.stats.skippedAlreadySent).toBe(1);
     expect(result.stats.failed).toBe(0);
     expect(result.stats.batchCount).toBe(1);
+    expectCronTimings(result.stats);
 
     // Already-sent user must not trigger digest construction or template
     // rendering — the early dedupe check should skip them entirely.

--- a/server/automated-emails/run.ts
+++ b/server/automated-emails/run.ts
@@ -98,6 +98,20 @@ type PreparedAutomatedEmailJobResult =
           };
     };
 
+interface AutomatedEmailCronTimingsMs {
+  total: number;
+  loadCandidates: number;
+  scheduleEvaluation: number;
+  recipientLookup: number;
+  digestAndTemplatePreparation: number;
+  providerSend: number;
+}
+
+type AutomatedEmailCronTimingKey = Exclude<
+  keyof AutomatedEmailCronTimingsMs,
+  "total"
+>;
+
 export interface AutomatedEmailCronStats {
   enabled: boolean;
   now: string;
@@ -116,6 +130,7 @@ export interface AutomatedEmailCronStats {
   failed: number;
   batchCount: number;
   missingEnvVars: string[];
+  timingsMs: AutomatedEmailCronTimingsMs;
 }
 
 interface RunAutomatedEmailCronResult {
@@ -143,6 +158,43 @@ function resolveMissingAutomatedEmailEnvVars() {
   });
 }
 
+function createEmptyTimings(): AutomatedEmailCronTimingsMs {
+  return {
+    total: 0,
+    loadCandidates: 0,
+    scheduleEvaluation: 0,
+    recipientLookup: 0,
+    digestAndTemplatePreparation: 0,
+    providerSend: 0,
+  };
+}
+
+function resolveElapsedMs(startedAtMs: number) {
+  return Math.round((performance.now() - startedAtMs) * 100) / 100;
+}
+
+async function measureCronTiming<T>(params: {
+  stats: AutomatedEmailCronStats;
+  key: AutomatedEmailCronTimingKey;
+  operation: () => Promise<T>;
+}) {
+  const startedAtMs = performance.now();
+
+  try {
+    return await params.operation();
+  } finally {
+    params.stats.timingsMs[params.key] += resolveElapsedMs(startedAtMs);
+  }
+}
+
+function finalizeCronStats(
+  stats: AutomatedEmailCronStats,
+  cronStartedAtMs: number,
+) {
+  stats.timingsMs.total = resolveElapsedMs(cronStartedAtMs);
+  return stats;
+}
+
 function createBaseStats(
   now: Date,
   missingEnvVars: string[],
@@ -165,6 +217,7 @@ function createBaseStats(
     failed: 0,
     batchCount: 0,
     missingEnvVars,
+    timingsMs: createEmptyTimings(),
   };
 }
 
@@ -410,6 +463,7 @@ async function prepareAutomatedEmailJob(params: {
 export async function runAutomatedEmailCron(
   now: Date = new Date(),
 ): Promise<RunAutomatedEmailCronResult> {
+  const cronStartedAtMs = performance.now();
   const missingEnvVars = resolveMissingAutomatedEmailEnvVars();
   const baseStats = createBaseStats(now, missingEnvVars);
 
@@ -417,7 +471,7 @@ export async function runAutomatedEmailCron(
     return {
       success: true,
       message: "Automated emails are disabled",
-      stats: baseStats,
+      stats: finalizeCronStats(baseStats, cronStartedAtMs),
     };
   }
 
@@ -425,7 +479,7 @@ export async function runAutomatedEmailCron(
     return {
       success: true,
       message: "Automated emails skipped because configuration is incomplete",
-      stats: baseStats,
+      stats: finalizeCronStats(baseStats, cronStartedAtMs),
     };
   }
 
@@ -434,31 +488,40 @@ export async function runAutomatedEmailCron(
     return {
       success: true,
       message: "Automated emails skipped because configuration is incomplete",
-      stats: baseStats,
+      stats: finalizeCronStats(baseStats, cronStartedAtMs),
     };
   }
 
-  const [candidates, lastReengagementSentAtByUserId] = await Promise.all([
-    fetchAutomatedEmailCandidates(),
-    fetchRecentReengagementDeliveries(now),
-  ]);
-
-  const stats = {
-    ...baseStats,
-    scannedUsers: candidates.length,
-  };
-  const dueJobs = buildDueAutomatedEmailJobs({
-    candidates,
-    lastReengagementSentAtByUserId,
-    now,
+  const stats = baseStats;
+  const [candidates, lastReengagementSentAtByUserId] = await measureCronTiming({
     stats,
+    key: "loadCandidates",
+    operation: () =>
+      Promise.all([
+        fetchAutomatedEmailCandidates(),
+        fetchRecentReengagementDeliveries(now),
+      ]),
+  });
+
+  stats.scannedUsers = candidates.length;
+
+  const dueJobs = await measureCronTiming({
+    stats,
+    key: "scheduleEvaluation",
+    operation: async () =>
+      buildDueAutomatedEmailJobs({
+        candidates,
+        lastReengagementSentAtByUserId,
+        now,
+        stats,
+      }),
   });
 
   if (dueJobs.length === 0) {
     return {
       success: true,
       message: "No automated emails were due",
-      stats,
+      stats: finalizeCronStats(stats, cronStartedAtMs),
     };
   }
 
@@ -467,49 +530,64 @@ export async function runAutomatedEmailCron(
   for (const jobBatch of chunkArray(dueJobs, AUTOMATED_EMAIL_BATCH_SIZE)) {
     stats.batchCount += 1;
 
-    const recipientEmailsByUserId = await fetchRecipientEmailsByUserId(
-      jobBatch.map((job) => job.userId),
-    );
+    const recipientEmailsByUserId = await measureCronTiming({
+      stats,
+      key: "recipientLookup",
+      operation: () =>
+        fetchRecipientEmailsByUserId(jobBatch.map((job) => job.userId)),
+    });
 
-    const preparedBatchResults = await Promise.all(
-      jobBatch.map(async (job) => {
-        const recipientEmail = recipientEmailsByUserId.get(job.userId);
+    const preparedBatchResults = await measureCronTiming({
+      stats,
+      key: "digestAndTemplatePreparation",
+      operation: () =>
+        Promise.all(
+          jobBatch.map(async (job) => {
+            const recipientEmail = recipientEmailsByUserId.get(job.userId);
 
-        if (!recipientEmail) {
-          return {
-            ready: false as const,
-            result: {
-              success: true as const,
-              skipped: true as const,
-              reason: "no_email_address" as const,
-            },
-          };
-        }
+            if (!recipientEmail) {
+              return {
+                ready: false as const,
+                result: {
+                  success: true as const,
+                  skipped: true as const,
+                  reason: "no_email_address" as const,
+                },
+              };
+            }
 
-        try {
-          return await prepareAutomatedEmailJob({
-            job,
-            recipientEmail,
-            fromAddress,
-          });
-        } catch (error) {
-          return {
-            ready: false as const,
-            result: {
-              success: false as const,
-              errorMessage:
-                error instanceof Error ? error.message : "Unknown send error",
-            },
-          };
-        }
-      }),
-    );
+            try {
+              return await prepareAutomatedEmailJob({
+                job,
+                recipientEmail,
+                fromAddress,
+              });
+            } catch (error) {
+              return {
+                ready: false as const,
+                result: {
+                  success: false as const,
+                  errorMessage:
+                    error instanceof Error
+                      ? error.message
+                      : "Unknown send error",
+                },
+              };
+            }
+          }),
+        ),
+    });
     const sendInputs = preparedBatchResults.flatMap((preparedBatchResult) =>
       preparedBatchResult.ready ? [preparedBatchResult.input] : [],
     );
-    const sendResults = await sendAutomatedEmailBatch({
-      items: sendInputs,
-      sender,
+    const sendResults = await measureCronTiming({
+      stats,
+      key: "providerSend",
+      operation: () =>
+        sendAutomatedEmailBatch({
+          items: sendInputs,
+          sender,
+        }),
     });
     const batchResults = [
       ...preparedBatchResults.flatMap((preparedBatchResult) =>
@@ -552,6 +630,6 @@ export async function runAutomatedEmailCron(
       stats.failed > 0
         ? "Automated email cron completed with partial failures"
         : "Automated email cron completed",
-    stats,
+    stats: finalizeCronStats(stats, cronStartedAtMs),
   };
 }

--- a/server/dividends/fetch.test.ts
+++ b/server/dividends/fetch.test.ts
@@ -145,6 +145,22 @@ function mockResolvedSymbol() {
   });
 }
 
+function mockResolvedSymbols(
+  symbols: Array<{ input: string; canonicalId: string; providerAlias: string }>,
+) {
+  resolveSymbolsBatchMock.mockResolvedValue({
+    byInput: new Map(
+      symbols.map(({ canonicalId, input }) => [input, { canonicalId }]),
+    ),
+    byCanonicalId: new Map(
+      symbols.map(({ canonicalId, providerAlias }) => [
+        canonicalId,
+        { providerAlias },
+      ]),
+    ),
+  });
+}
+
 describe("fetchDividends", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -390,5 +406,72 @@ describe("fetchDividends", () => {
         last_dividend_date: "2025-12-15",
       }),
     );
+  });
+
+  it("does not fail the whole batch when one Yahoo dividend payload is malformed", async () => {
+    mockResolvedSymbols([
+      {
+        input: "sym-bad",
+        canonicalId: "sym-bad",
+        providerAlias: "BAD",
+      },
+      {
+        input: "sym-good",
+        canonicalId: "sym-good",
+        providerAlias: "GOOD",
+      },
+    ]);
+    const state: FakeDividendState = {
+      events: [],
+      summaries: [],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+    yahooQuoteSummaryMock.mockRejectedValue(
+      new Error("No fundamentals data found for symbol"),
+    );
+    yahooChartMock
+      .mockResolvedValueOnce({
+        events: {
+          dividends: [
+            {
+              date: "not-a-date",
+              amount: 1,
+            },
+          ],
+        },
+        meta: { currency: "USD" },
+      })
+      .mockResolvedValueOnce({
+        events: {
+          dividends: [
+            {
+              date: new Date("2025-12-15T00:00:00.000Z"),
+              amount: 1.25,
+            },
+          ],
+        },
+        meta: { currency: "USD" },
+      });
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([
+      { symbolId: "sym-bad" },
+      { symbolId: "sym-good" },
+    ]);
+
+    expect(result.has("sym-bad")).toBe(false);
+    expect(result.get("sym-good")?.summary).toEqual(
+      expect.objectContaining({
+        symbol_id: "sym-good",
+        pays_dividends: true,
+        last_dividend_date: "2025-12-15",
+      }),
+    );
+    expect(
+      state.upserts
+        .find((upsert) => upsert.table === "dividends")
+        ?.payload.map((summary) => (summary as Dividend).symbol_id),
+    ).toEqual(["sym-good"]);
   });
 });

--- a/server/dividends/fetch.test.ts
+++ b/server/dividends/fetch.test.ts
@@ -1,0 +1,394 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Dividend, DividendEvent } from "@/types/global.types";
+
+const yahooQuoteSummaryMock = vi.fn();
+const yahooChartMock = vi.fn();
+const createServiceClientMock = vi.fn();
+const resolveSymbolsBatchMock = vi.fn();
+
+vi.mock("@/server/yahoo-finance/client", () => ({
+  yahooFinance: {
+    quoteSummary: yahooQuoteSummaryMock,
+    chart: yahooChartMock,
+  },
+}));
+
+vi.mock("@/supabase/service", () => ({
+  createServiceClient: createServiceClientMock,
+}));
+
+vi.mock("@/server/symbols/resolve", () => ({
+  resolveSymbolsBatch: resolveSymbolsBatchMock,
+}));
+
+interface FakeDividendState {
+  events: DividendEvent[];
+  summaries: Dividend[];
+  upserts: Array<{
+    table: string;
+    payload: unknown[];
+    options?: Record<string, unknown>;
+  }>;
+}
+
+function createDividendSummary(overrides: Partial<Dividend> = {}): Dividend {
+  return {
+    symbol_id: "sym-1",
+    forward_annual_dividend: null,
+    trailing_ttm_dividend: null,
+    dividend_yield: null,
+    ex_dividend_date: null,
+    last_dividend_date: null,
+    inferred_frequency: null,
+    pays_dividends: true,
+    dividends_checked_at: "2025-01-01T00:00:00.000Z",
+    created_at: "2025-01-01T00:00:00.000Z",
+    updated_at: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createDividendEvent(
+  overrides: Partial<DividendEvent> = {},
+): DividendEvent {
+  return {
+    id: "event-1",
+    symbol_id: "sym-1",
+    event_date: "2024-12-15",
+    gross_amount: 1,
+    currency: "USD",
+    source: "yahoo",
+    created_at: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createFakeServiceClient(state: FakeDividendState) {
+  return {
+    from(table: string) {
+      let symbolIds: string[] = [];
+      const gteFilters: Record<string, string> = {};
+
+      const builder = {
+        select() {
+          return builder;
+        },
+        in(_column: string, values: string[]) {
+          symbolIds = values;
+          return builder;
+        },
+        gte(column: string, value: string) {
+          gteFilters[column] = value;
+          return builder;
+        },
+        upsert(payload: unknown[], options?: Record<string, unknown>) {
+          state.upserts.push({ table, payload, options });
+          return Promise.resolve({ data: null, error: null });
+        },
+        then(
+          onFulfilled: (value: unknown) => unknown,
+          onRejected?: (reason: unknown) => unknown,
+        ) {
+          return Promise.resolve(resolveSelect()).then(onFulfilled, onRejected);
+        },
+      };
+
+      function resolveSelect() {
+        if (table === "dividend_events") {
+          const data = state.events.filter((event) => {
+            if (!symbolIds.includes(event.symbol_id)) {
+              return false;
+            }
+
+            const eventDateThreshold = gteFilters.event_date;
+            return (
+              !eventDateThreshold ||
+              new Date(event.event_date) >= new Date(eventDateThreshold)
+            );
+          });
+
+          return { data, error: null };
+        }
+
+        if (table === "dividends") {
+          const data = state.summaries.filter((summary) => {
+            if (!symbolIds.includes(summary.symbol_id)) {
+              return false;
+            }
+
+            const updatedAtThreshold = gteFilters.updated_at;
+            return (
+              !updatedAtThreshold ||
+              new Date(summary.updated_at) >= new Date(updatedAtThreshold)
+            );
+          });
+
+          return { data, error: null };
+        }
+
+        return {
+          data: null,
+          error: { message: `Unexpected table in test stub: ${table}` },
+        };
+      }
+
+      return builder;
+    },
+  };
+}
+
+function mockResolvedSymbol() {
+  resolveSymbolsBatchMock.mockResolvedValue({
+    byInput: new Map([["sym-1", { canonicalId: "sym-1" }]]),
+    byCanonicalId: new Map([["sym-1", { providerAlias: "TEST" }]]),
+  });
+}
+
+describe("fetchDividends", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-04T09:00:00.000Z"));
+    yahooQuoteSummaryMock.mockReset();
+    yahooChartMock.mockReset();
+    createServiceClientMock.mockReset();
+    resolveSymbolsBatchMock.mockReset();
+    mockResolvedSymbol();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns stale cached data without live Yahoo calls when refreshMissing is false", async () => {
+    const state: FakeDividendState = {
+      events: [
+        createDividendEvent({
+          id: "old-event",
+          event_date: "2020-01-15",
+        }),
+        createDividendEvent({
+          id: "recent-event",
+          event_date: "2025-01-15",
+        }),
+      ],
+      summaries: [
+        createDividendSummary({
+          trailing_ttm_dividend: 12,
+          updated_at: "2020-01-01T00:00:00.000Z",
+          dividends_checked_at: "2020-01-01T00:00:00.000Z",
+        }),
+      ],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "sym-1" }], {
+      refreshMissing: false,
+    });
+
+    expect(yahooQuoteSummaryMock).not.toHaveBeenCalled();
+    expect(yahooChartMock).not.toHaveBeenCalled();
+    expect(state.upserts).toEqual([]);
+    expect(result.get("sym-1")?.summary.trailing_ttm_dividend).toBe(12);
+    expect(result.get("sym-1")?.events).toEqual([
+      expect.objectContaining({
+        id: "recent-event",
+        event_date: "2025-01-15",
+      }),
+    ]);
+  });
+
+  it("synthesizes a stale-cache summary from recent events when the summary row is missing", async () => {
+    const state: FakeDividendState = {
+      events: [
+        createDividendEvent({
+          id: "first-event",
+          event_date: "2025-03-15",
+        }),
+        createDividendEvent({
+          id: "second-event",
+          event_date: "2025-06-15",
+        }),
+      ],
+      summaries: [],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "sym-1" }], {
+      refreshMissing: false,
+    });
+
+    expect(yahooQuoteSummaryMock).not.toHaveBeenCalled();
+    expect(yahooChartMock).not.toHaveBeenCalled();
+    expect(result.get("sym-1")?.summary).toEqual(
+      expect.objectContaining({
+        symbol_id: "sym-1",
+        pays_dividends: true,
+        inferred_frequency: "quarterly",
+        last_dividend_date: "2025-06-15",
+      }),
+    );
+  });
+
+  it("stores a non-payer marker for known Yahoo no-data errors", async () => {
+    const state: FakeDividendState = {
+      events: [],
+      summaries: [],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+    yahooQuoteSummaryMock.mockRejectedValue(
+      new Error("No fundamentals data found for symbol: TEST"),
+    );
+    yahooChartMock.mockResolvedValue({
+      events: {},
+      meta: { currency: "USD" },
+    });
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "sym-1" }]);
+
+    const dividendSummaryUpsert = state.upserts.find(
+      (upsert) => upsert.table === "dividends",
+    );
+    expect(dividendSummaryUpsert?.payload).toEqual([
+      expect.objectContaining({
+        symbol_id: "sym-1",
+        pays_dividends: false,
+        dividends_checked_at: "2026-05-04T09:00:00.000Z",
+      }),
+    ]);
+    expect(result.get("sym-1")?.summary.pays_dividends).toBe(false);
+  });
+
+  it("does not cache a non-payer marker for transient provider failures", async () => {
+    const state: FakeDividendState = {
+      events: [],
+      summaries: [],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+    yahooQuoteSummaryMock.mockRejectedValue(new Error("network timeout"));
+    yahooChartMock.mockResolvedValue({
+      events: {},
+      meta: { currency: "USD" },
+    });
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "sym-1" }]);
+
+    expect(state.upserts.some((upsert) => upsert.table === "dividends")).toBe(
+      false,
+    );
+    expect(result.has("sym-1")).toBe(false);
+  });
+
+  it("treats rate-limit status errors as transient provider failures", async () => {
+    const state: FakeDividendState = {
+      events: [],
+      summaries: [],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+    yahooQuoteSummaryMock.mockRejectedValue({
+      statusCode: 429,
+      message: "Too many requests",
+    });
+    yahooChartMock.mockResolvedValue({
+      events: {},
+      meta: { currency: "USD" },
+    });
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "sym-1" }]);
+
+    expect(state.upserts.some((upsert) => upsert.table === "dividends")).toBe(
+      false,
+    );
+    expect(result.has("sym-1")).toBe(false);
+  });
+
+  it("returns existing payer summaries when provider refreshes produce no data", async () => {
+    const state: FakeDividendState = {
+      events: [],
+      summaries: [
+        createDividendSummary({
+          trailing_ttm_dividend: 12,
+          updated_at: "2026-05-04T08:00:00.000Z",
+          dividends_checked_at: "2026-05-04T08:00:00.000Z",
+        }),
+      ],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+    yahooQuoteSummaryMock.mockRejectedValue(
+      new Error("No fundamentals data found for symbol: TEST"),
+    );
+    yahooChartMock.mockResolvedValue({
+      events: {},
+      meta: { currency: "USD" },
+    });
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "sym-1" }]);
+
+    expect(state.upserts.some((upsert) => upsert.table === "dividends")).toBe(
+      false,
+    );
+    expect(result.get("sym-1")?.summary).toEqual(
+      expect.objectContaining({
+        symbol_id: "sym-1",
+        pays_dividends: true,
+        trailing_ttm_dividend: 12,
+      }),
+    );
+  });
+
+  it("preserves successful dividend chart events when summary data is unavailable", async () => {
+    const state: FakeDividendState = {
+      events: [],
+      summaries: [],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+    yahooQuoteSummaryMock.mockRejectedValue(
+      new Error("No fundamentals data found for symbol: TEST"),
+    );
+    yahooChartMock.mockResolvedValue({
+      events: {
+        dividends: [
+          {
+            date: new Date("2025-12-15T00:00:00.000Z"),
+            amount: 1.25,
+          },
+        ],
+      },
+      meta: { currency: "USD" },
+    });
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "sym-1" }]);
+
+    expect(result.get("sym-1")?.summary.pays_dividends).toBe(true);
+    expect(result.get("sym-1")?.events).toEqual([
+      expect.objectContaining({
+        event_date: "2025-12-15",
+        gross_amount: 1.25,
+      }),
+    ]);
+    expect(
+      state.upserts
+        .find((upsert) => upsert.table === "dividends")
+        ?.payload.at(0),
+    ).toEqual(
+      expect.objectContaining({
+        pays_dividends: true,
+        last_dividend_date: "2025-12-15",
+      }),
+    );
+  });
+});

--- a/server/dividends/fetch.ts
+++ b/server/dividends/fetch.ts
@@ -6,20 +6,147 @@ import { v4 as uuidv4 } from "uuid";
 import { yahooFinance } from "@/server/yahoo-finance/client";
 import { createServiceClient } from "@/supabase/service";
 import { resolveSymbolsBatch } from "@/server/symbols/resolve";
+import {
+  extractStatusCode,
+  isTransientError,
+  stringifyError,
+} from "@/server/shared/retry";
 import { formatUTCDateKey } from "@/lib/date/date-utils";
 
 import type { Dividend, DividendEvent } from "@/types/global.types";
 
+export interface FetchDividendsOptions {
+  /**
+   * Write refreshed Yahoo results back to `dividends` and `dividend_events`.
+   * Defaults to true for normal user-facing reads.
+   */
+  upsert?: boolean;
+  /**
+   * Read existing dividend rows before calling Yahoo. Defaults to true.
+   * Use false for on-demand probes that should bypass cached data entirely.
+   */
+  readCache?: boolean;
+  /**
+   * Fetch missing or stale cache entries from Yahoo. Defaults to true.
+   * Use false for cron/email paths where predictable runtime matters more
+   * than refreshing dividend data.
+   */
+  refreshMissing?: boolean;
+}
+
+interface ResolvedFetchDividendsOptions {
+  upsert: boolean;
+  readCache: boolean;
+  refreshMissing: boolean;
+  allowStaleCache: boolean;
+}
+
+interface FetchedDividendResult {
+  symbolId: string;
+  events: DividendEvent[];
+  summary: Dividend | null;
+  shouldUpsert?: boolean;
+}
+
+function resolveFetchDividendsOptions(
+  options: FetchDividendsOptions = {},
+): ResolvedFetchDividendsOptions {
+  const refreshMissing = options.refreshMissing ?? true;
+  const readCache = options.readCache ?? true;
+
+  return {
+    upsert: options.upsert ?? true,
+    readCache,
+    refreshMissing,
+    allowStaleCache: readCache && refreshMissing === false,
+  };
+}
+
+function isTransientDividendProviderError(error: unknown) {
+  const statusCode = extractStatusCode(error);
+  if (statusCode === 408 || statusCode === 429) {
+    return true;
+  }
+
+  return isTransientError(error);
+}
+
+function isKnownNoDividendDataError(error: unknown) {
+  return /no fundamentals data/i.test(stringifyError(error));
+}
+
+function createNoDividendsMarker(symbolId: string): Dividend {
+  const now = new Date().toISOString();
+
+  return {
+    symbol_id: symbolId,
+    forward_annual_dividend: null,
+    trailing_ttm_dividend: null,
+    dividend_yield: null,
+    ex_dividend_date: null,
+    last_dividend_date: null,
+    inferred_frequency: null,
+    pays_dividends: false,
+    dividends_checked_at: now,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+function resolveLatestDividendEventDate(events: DividendEvent[]) {
+  let latestDate: string | null = null;
+
+  events.forEach((event) => {
+    if (!latestDate || event.event_date > latestDate) {
+      latestDate = event.event_date;
+    }
+  });
+
+  return latestDate;
+}
+
+/**
+ * Reconstruct a lightweight summary when stale cache mode finds event rows
+ * but no matching `dividends` row. This lets cron use known historical data
+ * without refreshing Yahoo during email sending.
+ */
+function createDividendSummaryFromEvents(
+  symbolId: string,
+  events: DividendEvent[],
+): Dividend {
+  const now = new Date().toISOString();
+
+  return {
+    symbol_id: symbolId,
+    forward_annual_dividend: null,
+    trailing_ttm_dividend: null,
+    dividend_yield: null,
+    ex_dividend_date: null,
+    last_dividend_date: resolveLatestDividendEventDate(events),
+    inferred_frequency: detectDividendFrequency(events),
+    pays_dividends: true,
+    dividends_checked_at: now,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
 /**
  * Fetch dividend data for multiple symbols in bulk.
  * @param requests - Array of {symbolId} objects
- * @param upsert - Whether to cache results in database (defaults to true)
+ * @param options - Cache read, provider refresh, and cache write behavior.
+ * Default: read fresh cache, refresh misses/stale entries from Yahoo, then
+ * upsert refreshed results. Cron/email callers pass `{ refreshMissing: false }`
+ * for cache-only reads that may use stale summaries. On-demand probes can pass
+ * `{ upsert: false }` to reuse cache and live-refresh without writing results.
  * @returns Map where key is symbolId and value is {events, summary} objects
  */
 export async function fetchDividends(
   requests: Array<{ symbolId: string }>,
-  upsert: boolean = true,
+  options: FetchDividendsOptions = {},
 ) {
+  const resolvedOptions = resolveFetchDividendsOptions(options);
+
   // Early return if no requests
   if (!requests.length) return new Map();
 
@@ -46,21 +173,23 @@ export async function fetchDividends(
   const eventsBySymbol = new Map<string, DividendEvent[]>();
   const summariesBySymbol = new Map<string, Dividend>();
 
-  if (upsert) {
+  if (resolvedOptions.readCache) {
     const eventsDateThreshold = subYears(new Date(), 3).toISOString();
     const summariesDateThreshold = subDays(new Date(), 7).toISOString();
+    const cachedEventsQuery = supabase
+      .from("dividend_events")
+      .select("*")
+      .in("symbol_id", canonicalIds);
+    const cachedSummariesQuery = supabase
+      .from("dividends")
+      .select("*")
+      .in("symbol_id", canonicalIds);
 
     const [cachedEvents, cachedSummaries] = await Promise.all([
-      supabase
-        .from("dividend_events")
-        .select("*")
-        .in("symbol_id", canonicalIds)
-        .gte("event_date", eventsDateThreshold),
-      supabase
-        .from("dividends")
-        .select("*")
-        .in("symbol_id", canonicalIds)
-        .gte("updated_at", summariesDateThreshold),
+      cachedEventsQuery.gte("event_date", eventsDateThreshold),
+      resolvedOptions.allowStaleCache
+        ? cachedSummariesQuery
+        : cachedSummariesQuery.gte("updated_at", summariesDateThreshold),
     ]);
 
     if (cachedEvents.error) {
@@ -92,21 +221,31 @@ export async function fetchDividends(
       const summary = summariesBySymbol.get(symbolId);
 
       const hasEvents = events.length > 0;
-      const hasSummary = !!summary;
       const isFreshCheck =
         summary?.dividends_checked_at &&
         new Date(summary.dividends_checked_at) >=
           new Date(summariesDateThreshold);
 
-      const isFreshNonPayer = summary?.pays_dividends === false && isFreshCheck;
-      const isFreshPayer =
-        summary?.pays_dividends === true && hasEvents && isFreshCheck;
+      if (resolvedOptions.allowStaleCache) {
+        if (summary) {
+          canonicalResults.set(symbolId, { events, summary });
+          return;
+        }
 
-      if (isFreshPayer || isFreshNonPayer) {
-        canonicalResults.set(symbolId, { events, summary: summary! });
+        if (!summary && hasEvents) {
+          canonicalResults.set(symbolId, {
+            events,
+            summary: createDividendSummaryFromEvents(symbolId, events),
+          });
+        }
       } else {
-        if (!hasEvents && !hasSummary) {
-          // Both missing - this is expected for new symbols
+        const isFreshNonPayer =
+          summary?.pays_dividends === false && isFreshCheck;
+        const isFreshPayer =
+          summary?.pays_dividends === true && hasEvents && isFreshCheck;
+
+        if (isFreshPayer || isFreshNonPayer) {
+          canonicalResults.set(symbolId, { events, summary: summary! });
         }
       }
     });
@@ -116,20 +255,20 @@ export async function fetchDividends(
     (symbolId) => !canonicalResults.has(symbolId),
   );
 
-  if (missingCanonicalIds.length > 0) {
+  if (resolvedOptions.refreshMissing && missingCanonicalIds.length > 0) {
     // 3) Fetch missing dividend data from Yahoo Finance (bulk per canonical symbol)
-    const fetchPromises = missingCanonicalIds.map(async (symbolId) => {
-      const resolution = byCanonicalId.get(symbolId);
-      const yahooTicker = resolution?.providerAlias;
-      if (!yahooTicker) {
-        console.error(
-          `Failed to fetch dividends for ${symbolId}: missing Yahoo ticker alias.`,
-        );
-        return { symbolId, events: [], summary: null as Dividend | null };
-      }
+    const fetchPromises = missingCanonicalIds.map(
+      async (symbolId): Promise<FetchedDividendResult> => {
+        const resolution = byCanonicalId.get(symbolId);
+        const yahooTicker = resolution?.providerAlias;
+        if (!yahooTicker) {
+          console.error(
+            `Failed to fetch dividends for ${symbolId}: missing Yahoo ticker alias.`,
+          );
+          return { symbolId, events: [], summary: null as Dividend | null };
+        }
 
-      try {
-        const [summary, chart] = await Promise.all([
+        const [summaryResult, chartResult] = await Promise.allSettled([
           yahooFinance.quoteSummary(yahooTicker, {
             modules: ["summaryDetail", "calendarEvents"],
           }),
@@ -139,9 +278,22 @@ export async function fetchDividends(
             events: "div",
           }),
         ]);
+        const summary =
+          summaryResult.status === "fulfilled" ? summaryResult.value : null;
+        const chart =
+          chartResult.status === "fulfilled" ? chartResult.value : null;
+        const providerErrors = [summaryResult, chartResult].flatMap((result) =>
+          result.status === "rejected" ? [result.reason] : [],
+        );
+        const hasTransientProviderError = providerErrors.some(
+          isTransientDividendProviderError,
+        );
+        const hasKnownNoDataError = providerErrors.some(
+          isKnownNoDividendDataError,
+        );
 
         const events: DividendEvent[] = [];
-        if (chart.events?.dividends) {
+        if (chart?.events?.dividends) {
           chart.events.dividends.forEach((dividend) => {
             events.push({
               id: uuidv4(),
@@ -156,101 +308,103 @@ export async function fetchDividends(
         }
 
         const inferred_frequency = detectDividendFrequency(events);
-        const last_dividend_date =
-          events.length > 0
-            ? events.sort(
-                (a, b) =>
-                  new Date(b.event_date).getTime() -
-                  new Date(a.event_date).getTime(),
-              )[0].event_date
-            : null;
+        const last_dividend_date = resolveLatestDividendEventDate(events);
 
         const hasDividendData =
-          summary.summaryDetail?.dividendRate ||
-          summary.summaryDetail?.trailingAnnualDividendRate ||
-          summary.summaryDetail?.dividendYield ||
-          (chart.events?.dividends && chart.events.dividends.length > 0);
+          summary?.summaryDetail?.dividendRate ||
+          summary?.summaryDetail?.trailingAnnualDividendRate ||
+          summary?.summaryDetail?.dividendYield ||
+          events.length > 0;
 
         if (hasDividendData) {
+          const now = new Date().toISOString();
           const summaryData: Dividend = {
             symbol_id: symbolId,
             forward_annual_dividend:
-              summary.summaryDetail?.dividendRate || null,
+              summary?.summaryDetail?.dividendRate || null,
             trailing_ttm_dividend:
-              summary.summaryDetail?.trailingAnnualDividendRate || null,
-            dividend_yield: summary.summaryDetail?.dividendYield || null,
-            ex_dividend_date: summary.calendarEvents?.exDividendDate
+              summary?.summaryDetail?.trailingAnnualDividendRate || null,
+            dividend_yield: summary?.summaryDetail?.dividendYield || null,
+            ex_dividend_date: summary?.calendarEvents?.exDividendDate
               ? formatUTCDateKey(summary.calendarEvents.exDividendDate)
               : null,
             last_dividend_date,
             inferred_frequency,
             pays_dividends: true,
-            dividends_checked_at: new Date().toISOString(),
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
+            dividends_checked_at: now,
+            created_at: now,
+            updated_at: now,
           };
 
           return { symbolId, events, summary: summaryData };
         }
 
-        // Avoid overwriting existing payer data if it exists
+        // Avoid overwriting existing payer data if it exists.
         const existingSummary = summariesBySymbol.get(symbolId);
-        const existingHasPayerData =
+        const existingHasPayerData = Boolean(
           existingSummary?.pays_dividends === true ||
           existingSummary?.forward_annual_dividend ||
           existingSummary?.trailing_ttm_dividend ||
           existingSummary?.dividend_yield ||
-          existingSummary?.last_dividend_date;
+          existingSummary?.last_dividend_date,
+        );
 
-        if (existingHasPayerData) {
-          return { symbolId, events, summary: null as Dividend | null };
+        if (existingSummary && existingHasPayerData) {
+          return {
+            symbolId,
+            events: eventsBySymbol.get(symbolId) || [],
+            summary: existingSummary,
+            shouldUpsert: false,
+          };
         }
 
-        const noDividendsMarker: Dividend = {
-          symbol_id: symbolId,
-          forward_annual_dividend: null,
-          trailing_ttm_dividend: null,
-          dividend_yield: null,
-          ex_dividend_date: null,
-          last_dividend_date: null,
-          inferred_frequency: null,
-          pays_dividends: false,
-          dividends_checked_at: new Date().toISOString(),
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        };
+        if (
+          hasTransientProviderError ||
+          (providerErrors.length > 0 && !hasKnownNoDataError)
+        ) {
+          console.warn(
+            `Failed to fetch dividends for ${symbolId} (${yahooTicker}):`,
+            providerErrors.map(stringifyError).join("; "),
+          );
+          return { symbolId, events: [], summary: null as Dividend | null };
+        }
 
-        return { symbolId, events, summary: noDividendsMarker };
-      } catch (error) {
-        console.error(
-          `Failed to fetch dividends for ${symbolId} (${yahooTicker}):`,
-          error,
-        );
-        return { symbolId, events: [], summary: null as Dividend | null };
-      }
-    });
+        return {
+          symbolId,
+          events,
+          summary: createNoDividendsMarker(symbolId),
+        };
+      },
+    );
 
     const fetchResults = await Promise.all(fetchPromises);
 
     const allEvents: DividendEvent[] = [];
     const allSummaries: Dividend[] = [];
 
-    fetchResults.forEach(({ symbolId, events, summary }) => {
-      if (events.length > 0) {
+    fetchResults.forEach(({ symbolId, events, summary, shouldUpsert }) => {
+      const shouldUpsertResult = shouldUpsert ?? true;
+
+      if (events.length > 0 && shouldUpsertResult) {
         allEvents.push(...events);
       }
 
       if (summary) {
         canonicalResults.set(symbolId, { events, summary });
-        allSummaries.push(summary);
+        if (shouldUpsertResult) {
+          allSummaries.push(summary);
+        }
       }
     });
 
-    if (upsert) {
+    if (resolvedOptions.upsert) {
       // Sort by PK components to avoid lock-order deadlocks
       allEvents.sort((a, b) => {
         if (a.symbol_id === b.symbol_id) {
-          return a.event_date.localeCompare(b.event_date);
+          if (a.event_date === b.event_date) {
+            return 0;
+          }
+          return a.event_date < b.event_date ? -1 : 1;
         }
         return a.symbol_id.localeCompare(b.symbol_id);
       });
@@ -307,10 +461,12 @@ function detectDividendFrequency(events: DividendEvent[]): string {
   if (events.length < 2) return "irregular";
 
   // Sort events by date
-  const sortedEvents = events.sort(
-    (a, b) =>
-      new Date(a.event_date).getTime() - new Date(b.event_date).getTime(),
-  );
+  const sortedEvents = events.slice().sort((a, b) => {
+    if (a.event_date === b.event_date) {
+      return 0;
+    }
+    return a.event_date < b.event_date ? -1 : 1;
+  });
 
   // Calculate gaps between payments in months
   const gaps = sortedEvents.reduce((acc, curr, i) => {

--- a/server/dividends/fetch.ts
+++ b/server/dividends/fetch.ts
@@ -131,6 +131,33 @@ function createDividendSummaryFromEvents(
   };
 }
 
+function resolveExistingPayerDividendResult(params: {
+  symbolId: string;
+  eventsBySymbol: Map<string, DividendEvent[]>;
+  summariesBySymbol: Map<string, Dividend>;
+}): FetchedDividendResult | null {
+  const { eventsBySymbol, summariesBySymbol, symbolId } = params;
+  const existingSummary = summariesBySymbol.get(symbolId);
+  const existingHasPayerData = Boolean(
+    existingSummary?.pays_dividends === true ||
+    existingSummary?.forward_annual_dividend ||
+    existingSummary?.trailing_ttm_dividend ||
+    existingSummary?.dividend_yield ||
+    existingSummary?.last_dividend_date,
+  );
+
+  if (!existingSummary || !existingHasPayerData) {
+    return null;
+  }
+
+  return {
+    symbolId,
+    events: eventsBySymbol.get(symbolId) || [],
+    summary: existingSummary,
+    shouldUpsert: false,
+  };
+}
+
 /**
  * Fetch dividend data for multiple symbols in bulk.
  * @param requests - Array of {symbolId} objects
@@ -268,112 +295,119 @@ export async function fetchDividends(
           return { symbolId, events: [], summary: null as Dividend | null };
         }
 
-        const [summaryResult, chartResult] = await Promise.allSettled([
-          yahooFinance.quoteSummary(yahooTicker, {
-            modules: ["summaryDetail", "calendarEvents"],
-          }),
-          yahooFinance.chart(yahooTicker, {
-            period1: subYears(new Date(), 3),
-            period2: new Date(),
-            events: "div",
-          }),
-        ]);
-        const summary =
-          summaryResult.status === "fulfilled" ? summaryResult.value : null;
-        const chart =
-          chartResult.status === "fulfilled" ? chartResult.value : null;
-        const providerErrors = [summaryResult, chartResult].flatMap((result) =>
-          result.status === "rejected" ? [result.reason] : [],
-        );
-        const hasTransientProviderError = providerErrors.some(
-          isTransientDividendProviderError,
-        );
-        const hasKnownNoDataError = providerErrors.some(
-          isKnownNoDividendDataError,
-        );
+        try {
+          const [summaryResult, chartResult] = await Promise.allSettled([
+            yahooFinance.quoteSummary(yahooTicker, {
+              modules: ["summaryDetail", "calendarEvents"],
+            }),
+            yahooFinance.chart(yahooTicker, {
+              period1: subYears(new Date(), 3),
+              period2: new Date(),
+              events: "div",
+            }),
+          ]);
+          const summary =
+            summaryResult.status === "fulfilled" ? summaryResult.value : null;
+          const chart =
+            chartResult.status === "fulfilled" ? chartResult.value : null;
+          const providerErrors = [summaryResult, chartResult].flatMap(
+            (result) => (result.status === "rejected" ? [result.reason] : []),
+          );
+          const hasTransientProviderError = providerErrors.some(
+            isTransientDividendProviderError,
+          );
+          const hasKnownNoDataError = providerErrors.some(
+            isKnownNoDividendDataError,
+          );
 
-        const events: DividendEvent[] = [];
-        if (chart?.events?.dividends) {
-          chart.events.dividends.forEach((dividend) => {
-            events.push({
-              id: uuidv4(),
-              symbol_id: symbolId,
-              event_date: formatUTCDateKey(dividend.date),
-              gross_amount: dividend.amount,
-              currency: chart.meta.currency || "USD",
-              source: "yahoo",
-              created_at: new Date().toISOString(),
+          const events: DividendEvent[] = [];
+          if (chart?.events?.dividends) {
+            chart.events.dividends.forEach((dividend) => {
+              events.push({
+                id: uuidv4(),
+                symbol_id: symbolId,
+                event_date: formatUTCDateKey(dividend.date),
+                gross_amount: dividend.amount,
+                currency: chart.meta.currency || "USD",
+                source: "yahoo",
+                created_at: new Date().toISOString(),
+              });
             });
+          }
+
+          const inferred_frequency = detectDividendFrequency(events);
+          const last_dividend_date = resolveLatestDividendEventDate(events);
+
+          const hasDividendData =
+            summary?.summaryDetail?.dividendRate ||
+            summary?.summaryDetail?.trailingAnnualDividendRate ||
+            summary?.summaryDetail?.dividendYield ||
+            events.length > 0;
+
+          if (hasDividendData) {
+            const now = new Date().toISOString();
+            const summaryData: Dividend = {
+              symbol_id: symbolId,
+              forward_annual_dividend:
+                summary?.summaryDetail?.dividendRate || null,
+              trailing_ttm_dividend:
+                summary?.summaryDetail?.trailingAnnualDividendRate || null,
+              dividend_yield: summary?.summaryDetail?.dividendYield || null,
+              ex_dividend_date: summary?.calendarEvents?.exDividendDate
+                ? formatUTCDateKey(summary.calendarEvents.exDividendDate)
+                : null,
+              last_dividend_date,
+              inferred_frequency,
+              pays_dividends: true,
+              dividends_checked_at: now,
+              created_at: now,
+              updated_at: now,
+            };
+
+            return { symbolId, events, summary: summaryData };
+          }
+
+          // Avoid overwriting existing payer data if it exists.
+          const existingPayerResult = resolveExistingPayerDividendResult({
+            symbolId,
+            eventsBySymbol,
+            summariesBySymbol,
           });
-        }
 
-        const inferred_frequency = detectDividendFrequency(events);
-        const last_dividend_date = resolveLatestDividendEventDate(events);
+          if (existingPayerResult) {
+            return existingPayerResult;
+          }
 
-        const hasDividendData =
-          summary?.summaryDetail?.dividendRate ||
-          summary?.summaryDetail?.trailingAnnualDividendRate ||
-          summary?.summaryDetail?.dividendYield ||
-          events.length > 0;
+          if (
+            hasTransientProviderError ||
+            (providerErrors.length > 0 && !hasKnownNoDataError)
+          ) {
+            console.warn(
+              `Failed to fetch dividends for ${symbolId} (${yahooTicker}):`,
+              providerErrors.map(stringifyError).join("; "),
+            );
+            return { symbolId, events: [], summary: null as Dividend | null };
+          }
 
-        if (hasDividendData) {
-          const now = new Date().toISOString();
-          const summaryData: Dividend = {
-            symbol_id: symbolId,
-            forward_annual_dividend:
-              summary?.summaryDetail?.dividendRate || null,
-            trailing_ttm_dividend:
-              summary?.summaryDetail?.trailingAnnualDividendRate || null,
-            dividend_yield: summary?.summaryDetail?.dividendYield || null,
-            ex_dividend_date: summary?.calendarEvents?.exDividendDate
-              ? formatUTCDateKey(summary.calendarEvents.exDividendDate)
-              : null,
-            last_dividend_date,
-            inferred_frequency,
-            pays_dividends: true,
-            dividends_checked_at: now,
-            created_at: now,
-            updated_at: now,
-          };
-
-          return { symbolId, events, summary: summaryData };
-        }
-
-        // Avoid overwriting existing payer data if it exists.
-        const existingSummary = summariesBySymbol.get(symbolId);
-        const existingHasPayerData = Boolean(
-          existingSummary?.pays_dividends === true ||
-          existingSummary?.forward_annual_dividend ||
-          existingSummary?.trailing_ttm_dividend ||
-          existingSummary?.dividend_yield ||
-          existingSummary?.last_dividend_date,
-        );
-
-        if (existingSummary && existingHasPayerData) {
           return {
             symbolId,
-            events: eventsBySymbol.get(symbolId) || [],
-            summary: existingSummary,
-            shouldUpsert: false,
+            events,
+            summary: createNoDividendsMarker(symbolId),
           };
-        }
-
-        if (
-          hasTransientProviderError ||
-          (providerErrors.length > 0 && !hasKnownNoDataError)
-        ) {
+        } catch (error) {
           console.warn(
-            `Failed to fetch dividends for ${symbolId} (${yahooTicker}):`,
-            providerErrors.map(stringifyError).join("; "),
+            `Failed to parse dividends for ${symbolId} (${yahooTicker}):`,
+            error,
           );
-          return { symbolId, events: [], summary: null as Dividend | null };
-        }
 
-        return {
-          symbolId,
-          events,
-          summary: createNoDividendsMarker(symbolId),
-        };
+          return (
+            resolveExistingPayerDividendResult({
+              symbolId,
+              eventsBySymbol,
+              summariesBySymbol,
+            }) ?? { symbolId, events: [], summary: null as Dividend | null }
+          );
+        }
       },
     );
 

--- a/server/shared/retry.ts
+++ b/server/shared/retry.ts
@@ -35,11 +35,11 @@ export interface RetryOptions {
   onRetry?: (context: RetryAttemptContext) => void;
 }
 
-function isObjectLike(value: unknown): value is Record<string, unknown> {
+export function isObjectLike(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function extractStatusCode(error: unknown): number | null {
+export function extractStatusCode(error: unknown): number | null {
   if (!isObjectLike(error)) return null;
 
   // Support both `status` (Fetch-style) and `statusCode` (Node/client libs).
@@ -52,7 +52,7 @@ function extractStatusCode(error: unknown): number | null {
   return null;
 }
 
-function stringifyError(error: unknown): string {
+export function stringifyError(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (typeof error === "string") return error;
   if (isObjectLike(error) && typeof error.message === "string") {


### PR DESCRIPTION
## Summary
- Make automated email digests use cache-only dividend reads for projected income.
- Add named dividend fetch options for cache reads, provider refreshes, and cache writes.
- Cache known Yahoo no-data dividend misses as non-payers while avoiding negative cache writes for transient failures.
- Add automated-email cron timing stats to the JSON response/logs.

## Notes
- No database migration needed.
- Dashboard/projected-income interactive flows keep their normal refresh behavior.
- Automated emails now omit projected income when cached dividend data is unavailable instead of fetching live Yahoo data during cron.