### PR TITLE
feat(currencies): Normalize provider quote units (GBp/GBX/KWF) into ISO currency across symbols, quotes, dividends, and import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ supabase/.temp/
 supabase/config.toml
 supabase/.branches/
 supabase/snippets/
+
+# temporary files
+*.tmp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,14 @@
 - Favor explicit, typed, functional code over clever abstractions.
 - Optimize for cache/batching; avoid N+1 database calls.
 
+## Planning & Execution Guardrails
+
+- For phased plans, stop after each phase and wait for explicit user approval before continuing.
+- Do not run Supabase CLI commands, Next CLI commands, or any command against any database or production system.
+- Allowed verification commands are limited to lint, type, format-check, and test checks.
+- Do not create Supabase migration files. Ask the user to create an empty migration file first, then edit that file only after it exists.
+- Once the migration file is ready, the user will apply the migration against the local database and they will regenerate the types.
+
 ## Architecture
 
 - Favor React Server Components (RSC) over Client Components

--- a/components/dashboard/positions/import/csv-form.tsx
+++ b/components/dashboard/positions/import/csv-form.tsx
@@ -116,7 +116,19 @@ export function CSVImportForm() {
             <span className="text-foreground font-medium">
               Required columns:
             </span>{" "}
-            name, currency, quantity,{" "}
+            name,{" "}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-foreground inline-block cursor-help underline-offset-4 hover:underline">
+                  currency
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                Use the ISO accounting currency. For symbol rows, broker quote
+                units are normalized automatically when recognized.
+              </TooltipContent>
+            </Tooltip>
+            , quantity,{" "}
             <Tooltip>
               <TooltipTrigger asChild>
                 <span className="text-foreground inline-block cursor-help underline-offset-4 hover:underline">
@@ -125,8 +137,8 @@ export function CSVImportForm() {
               </TooltipTrigger>
               <TooltipContent className="max-w-xs">
                 Unit value is required unless a symbol lookup is provided. When
-                a lookup (ticker/ISIN/etc.) is present we fetch the price for
-                you.
+                a recognized quote unit (GBX, GBp, KWF, etc.) is used for a
+                symbol row, the amount is scaled into the ISO currency.
               </TooltipContent>
             </Tooltip>
             .

--- a/components/dashboard/positions/import/review/form.tsx
+++ b/components/dashboard/positions/import/review/form.tsx
@@ -312,8 +312,8 @@ export function ReviewForm({
                       <Info className="size-4" />
                     </TooltipTrigger>
                     <TooltipContent>
-                      Currency is automatically set to the currency of the
-                      symbol if a symbol is provided.
+                      Symbol-backed rows use the symbol&apos;s normalized ISO
+                      accounting currency.
                     </TooltipContent>
                   </Tooltip>
                 </span>
@@ -328,8 +328,8 @@ export function ReviewForm({
                     </TooltipTrigger>
                     <TooltipContent>
                       Unit value is required unless symbol is provided. For
-                      assets with symbol, the unit value will be fetched from
-                      the market.
+                      symbols using a recognized quote unit, imported amounts
+                      are scaled into the ISO currency.
                     </TooltipContent>
                   </Tooltip>
                 </span>

--- a/docs/MARKET-DATA-HUB.md
+++ b/docs/MARKET-DATA-HUB.md
@@ -13,6 +13,11 @@
 
 - No extra database "hub" table is required. Reads use identifiers already stored on `positions`.
 
+- Currency reference data remains ISO-only. Provider quote units such as GBp,
+  GBX, and KWF are decoded at symbol-ingestion time and persisted on
+  `symbols.quote_currency` / `symbols.quote_to_currency_rate`; market-data
+  handlers should store normalized ISO-currency values in downstream caches.
+
 - Registry-based operations route by handler source:
 
 ```ts

--- a/docs/QUOTE-CACHE-RESEED.md
+++ b/docs/QUOTE-CACHE-RESEED.md
@@ -34,6 +34,10 @@ Use a two-stage refill:
 
 This avoids unnecessary provider traffic and keeps operational risk low.
 
+Quote rows should be reseeded as normalized ISO-currency prices. For securities
+whose provider prices arrive in quote units such as GBp/GBX or KWF, the runtime
+fetcher applies `symbols.quote_to_currency_rate` before writing `public.quotes`.
+
 ## Procedure
 
 ### 1) Optional maintenance window

--- a/docs/QUOTE-FETCH-BEHAVIOR.md
+++ b/docs/QUOTE-FETCH-BEHAVIOR.md
@@ -18,8 +18,27 @@ It focuses on behavior, not implementation details, so it should stay useful eve
 - exact cache hit: a `quotes` row exists for the exact effective date
 - cached fallback: use the latest prior cached quote within the configured stale window
 - live read repair: call Yahoo Finance for unresolved requests and upsert returned market-day rows
+- quote unit: a provider price unit that is not an ISO currency, such as GBp/GBX
+  for pence or KWF for Kuwaiti fils
 
 ## Core Rules
+
+### 0) Provider quote units are normalized before storage
+
+`public.currencies` stays ISO-only. Symbol metadata stores both:
+
+- `currency`: normalized ISO accounting currency, such as GBP or KWD
+- `quote_currency`: original provider quote unit, such as GBp, GBX, or KWF
+- `quote_to_currency_rate`: multiplier from provider quote unit into the ISO
+  currency
+
+Quote cache rows store normalized major-currency prices. For example, a raw
+Yahoo close of `524.4` in GBp is cached as `5.244` GBP, and a raw close of
+`838` in KWF is cached as `0.838` KWD.
+
+Yahoo chart dividend events follow the same rule. Summary dividend fields are
+not blindly scaled because Yahoo can already report those as major-currency
+annual values.
 
 ### 1) Quote rows are stored only for provider market days
 
@@ -145,7 +164,9 @@ This prevents old market data from overriding a newer snapshot state.
 ## Related Files
 
 - `server/quotes/fetch.ts`
+- `server/market-data/quote-units.ts`
 - `server/market-data/sources/symbol-handler.ts`
+- `server/dividends/fetch.ts`
 - `server/analysis/net-worth/net-worth-history.ts`
 - `server/analysis/valuations-history/synthesize.ts`
 

--- a/docs/quote-unit-normalization-plan.md
+++ b/docs/quote-unit-normalization-plan.md
@@ -1,0 +1,179 @@
+# Quote Unit Normalization Plan
+
+## Summary
+
+Implement UK and Kuwait market support by keeping `public.currencies`
+ISO-only and normalizing provider quote units like `GBp`/`GBX` and `KWF`
+into major ISO currencies before values enter symbols, quote cache, dividend
+events, positions, FX, P/L, and display. Deployment/admin workflows manage the
+available ISO currency list, including `KWD`.
+
+Execution is split into reviewable phases. At the end of every phase, the agent
+must stop, summarize changed files and checks run, and wait for your explicit
+green light before continuing.
+
+## Phase 0: Add Repo Guardrails To `AGENTS.md`
+
+Add a concise section to root `AGENTS.md`, near Development Principles or
+References:
+
+```md
+## Planning & Execution Guardrails
+
+- For phased plans, stop after each phase and wait for explicit user approval before continuing.
+- Do not run Supabase CLI commands, Next CLI commands, or any command against any database or production system.
+- Allowed verification commands are limited to lint, type, format-check, and test checks.
+- Do not create Supabase migration files. Ask the user to create an empty migration file first, then edit that file only after it exists.
+```
+
+Verification for this phase:
+
+- `npm run format:check` if practical.
+- Do not run `npm run type`, because it invokes `next typegen`.
+
+Pause for review.
+
+## Phase 1: Add Quote Unit Normalization Code
+
+Add a small internal quote-unit helper, for example under
+`server/market-data/quote-units.ts`, with a typed mapping:
+
+- `GBp`, `GBX` -> `GBP`, multiplier `0.01`
+- `KWF` -> `KWD`, multiplier `0.001`
+- ISO currency codes -> same currency, multiplier `1`
+- unsupported provider units return a clear unsupported quote-unit error
+
+Use this helper when fetching Yahoo symbol metadata so `symbols.currency` stores
+the normalized ISO currency, while separate symbol metadata stores the original
+quote unit and multiplier.
+
+Update import/validation messaging so symbol-backed position currency means
+normalized ISO accounting currency, not provider quote unit.
+
+Tests:
+
+- unit tests for quote-unit mapping and unsupported units
+- symbol validation/creation tests for `GBp -> GBP` and `KWF -> KWD`
+
+Allowed checks:
+
+- targeted Vitest tests
+- `npm run lint`
+- `npm run format:check`
+- `./node_modules/.bin/tsc --noEmit` only if it does not require Next-generated
+  type updates
+
+Pause for review.
+
+## Phase 2: Migration, After User Creates Empty File
+
+The agent must ask you to create an empty Supabase migration file. It must not
+create the file itself and must not run Supabase CLI.
+
+Once the empty migration exists, add SQL to:
+
+- add symbol quote metadata:
+  - `quote_currency text not null default currency`
+  - `quote_to_currency_rate numeric(20,10) not null default 1`
+  - check constraint requiring `quote_to_currency_rate > 0`
+- backfill existing symbols to `quote_currency = currency`, multiplier `1`
+- add no new FK from `quote_currency` to `currencies`, because quote units are
+  not always ISO
+
+Do not insert currencies in migrations; users/admins manage the rows in
+`public.currencies` separately.
+
+Update `types/database.types.ts` manually to match the migration, unless you
+explicitly run Supabase typegen yourself.
+
+Tests:
+
+- type-level compile coverage through existing symbol insert/update usage
+- any affected symbol fixture tests
+
+Pause for review.
+
+## Phase 3: Normalize Quote Cache Prices
+
+Update quote fetching so raw Yahoo chart prices are scaled before caching or
+returning:
+
+- `close_price = rawClose * quote_to_currency_rate`
+- `adjusted_close_price = rawAdjustedClose * quote_to_currency_rate`
+- fallback `regularMarketPrice` is scaled the same way
+
+Extend symbol batch resolution to include `quote_to_currency_rate`, avoiding N+1
+lookups.
+
+Existing downstream valuation should remain unchanged because
+`fetchPositions({ asOfDateKey })` already uses cached quote prices directly as
+unit values.
+
+Tests:
+
+- `BP.L`-style fixture: raw `524.4 GBp` returns/stores `5.244 GBP`
+- `NBK.KW`-style fixture: raw `838 KWF` returns/stores `0.838 KWD`
+- existing USD/EUR quote behavior remains multiplier `1`
+
+Pause for review.
+
+## Phase 4: Normalize Dividend Event Amounts
+
+Apply quote-unit normalization only to chart dividend event amounts, because
+Yahoo chart events use `chart.meta.currency`.
+
+Do not blindly scale `summaryDetail.dividendRate`,
+`trailingAnnualDividendRate`, or yield-derived values; those fields can already
+be in major currency.
+
+Store dividend events with ISO currency and scaled gross amount.
+
+Tests:
+
+- UK chart dividend event `6.1780996 GBp` stores `0.061780996 GBP`
+- Kuwait chart dividend event `35 KWF` stores `0.035 KWD`
+- projected income still uses ISO event currency
+
+Pause for review.
+
+## Phase 5: Import, UI, Docs, And Final Verification
+
+Update user-facing import/AI guidance:
+
+- position `currency` must be ISO accounting currency
+- `GBX`, `GBp`, and `KWF` in broker files are accepted as quote units and
+  normalized
+- symbol-backed unit values/cost basis must end up in the normalized ISO currency
+
+Update relevant docs/runbooks to mention quote-unit normalization and the fact
+that `public.currencies` remains ISO-only.
+
+Final allowed checks:
+
+- targeted Vitest suites for symbols, quotes, dividends, imports
+- `npm run test -- --run`
+- `npm run lint`
+- `npm run format:check`
+- `./node_modules/.bin/tsc --noEmit` if feasible without invoking Next CLI
+
+Explicitly forbidden throughout:
+
+- `supabase` CLI
+- `next` CLI
+- `npm run build`, `npm run dev`, `npm run type`
+- any command against local, staging, or production databases
+- creating migration files from scratch
+
+## Assumptions
+
+- `positions.currency`, `symbols.currency`, `dividend_events.currency`,
+  profiles, financial profiles, and `exchange_rates` remain ISO-only.
+- Quote cache rows should store normalized major-currency unit prices, not raw
+  provider quote-unit prices.
+- `server/market-data/quote-units.ts` can keep the small provider-unit mapping
+  for now. If it grows beyond a handful of deterministic quote units, revisit an
+  admin-managed mapping table while keeping `symbols.quote_to_currency_rate` as
+  the persisted per-symbol source of truth.
+- Historical existing quote rows do not need automatic data migration unless you
+  already have affected UK/Kuwait symbols in production; if so, handle reseeding
+  separately outside this agent workflow.

--- a/lib/import/positions/ai-extraction.ts
+++ b/lib/import/positions/ai-extraction.ts
@@ -135,6 +135,7 @@ export async function postProcessExtractedPositions(
   const {
     positions: normalizedPositions,
     warnings: normalizationWarnings,
+    errors: normalizationErrors,
     symbolValidationResults,
   } = await normalizePositionsArray(initial);
 
@@ -143,6 +144,7 @@ export async function postProcessExtractedPositions(
     normalizedPositions,
     symbolValidationResults,
   );
+  const errors = [...normalizationErrors, ...validationErrors];
 
   // Map raw warnings and merge with normalization warnings
   const warnRaw = obj.warnings ?? [];
@@ -160,13 +162,13 @@ export async function postProcessExtractedPositions(
     (c) => c.alphabetic_code,
   );
 
-  if (validationErrors.length > 0) {
+  if (errors.length > 0) {
     // Validation failed: return parsed positions alongside errors so user can review/fix
     return {
       success: false,
       positions: normalizedPositions,
       warnings: mergedWarnings.length ? mergedWarnings : undefined,
-      errors: validationErrors,
+      errors,
       symbolValidation,
       supportedCurrencies,
     };

--- a/lib/import/positions/ai-extraction.ts
+++ b/lib/import/positions/ai-extraction.ts
@@ -77,8 +77,9 @@ export async function createExtractionPrompt(): Promise<string> {
 
 Return data that strictly matches the provided JSON schema. Do not invent values:
 - If a field is unreadable or not present, set it to null and add a helpful warning in "warnings".
-- Currency must be a 3-letter ISO 4217 code in uppercase (e.g., USD, EUR, CHF). Do not include symbols.
-- When symbolLookup is present, set currency to the symbol's native trading currency from Yahoo Finance, never the page's base/portfolio currency.
+- Currency must be the 3-letter ISO 4217 accounting currency in uppercase (e.g., USD, EUR, GBP). Do not include symbols or provider quote units.
+- When symbolLookup is present, set currency to the symbol's normalized ISO accounting currency from Yahoo Finance, never the page's base/portfolio currency.
+- If a broker statement uses quote units, normalize them before output: GBp/GBX prices are pence, so use currency GBP and divide unit_value/cost_basis_per_unit by 100; KWF prices are Kuwaiti fils, so use currency KWD and divide unit_value/cost_basis_per_unit by 1000.
 - Quantity can be fractional, must be >= 0.
 - Unit numbers: strip thousand separators, use "." for decimals, no currency symbols.
 - category_id must be one of: ${categoriesList}.
@@ -87,7 +88,7 @@ Return data that strictly matches the provided JSON schema. Do not invent values
 - For cryptocurrencies, set symbolLookup to the Yahoo Finance crypto pair with "-USD" (e.g., BTC-USD, ETH-USD, XRP-USD). If only the coin code is visible, output the "-USD" pair. Set currency to USD for cryptocurrencies.
 - For listed securities with a recognizable symbol (Yahoo Finance tickers, e.g., AAPL, VT, VWCE.DE), set symbolLookup and you MAY set unit_value to null (it will be fetched).
 - If a row looks like a tradable ticker (uppercase letters/numbers 1–8 chars, e.g., PLTR, NVDA, QQQ), you MUST set symbolLookup to that ticker. If uncertain, set your best guess and add a warning like "symbol uncertain". Do not leave symbolLookup empty for listed securities.
-- cost_basis_per_unit: if an explicit "avg cost"/"average price"/"cost basis"/etc. column exists, set it; otherwise set null. It must be in the same currency as "currency".
+- cost_basis_per_unit: if an explicit "avg cost"/"average price"/"cost basis"/etc. column exists, set it; otherwise set null. It must be in the same normalized ISO currency as "currency".
 - capital_gains_tax_rate: if a tax rate column or tax information is present, extract it as either decimal (0..1) or percentage (0..100). If missing, set null.
  - If multiple rows refer to the same symbol/name, prefer a single merged position summing quantities. If cost basis differs across rows, set cost_basis_per_unit to null and add a warning.
 - Use full company names for the "name" field (e.g., "Ford Motor Company", "Toyota Motor Corporation"), not ticker symbols. Symbols go in "symbolLookup".

--- a/lib/import/positions/header-mapper.ts
+++ b/lib/import/positions/header-mapper.ts
@@ -119,7 +119,8 @@ const POSITION_HEADER_ALIASES: Record<PositionCanonicalHeader, string[]> = {
     "cgt rate",
   ],
 
-  // Currency code (ISO 4217 where possible)
+  // Position accounting currency. Symbol-backed imports may arrive with broker
+  // quote units such as GBX/GBp/KWF; normalization converts those to ISO.
   currency: [
     "currency",
     "ccy",

--- a/lib/import/positions/parse-csv.test.ts
+++ b/lib/import/positions/parse-csv.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import { parsePositionsCSV } from "./parse-csv";
 import { positionsToCSV } from "./serialize";
+
+const { validateSymbolsBatchMock } = vi.hoisted(() => ({
+  validateSymbolsBatchMock: vi.fn(),
+}));
 
 // Mock only the currencies fetch function
 vi.mock("@/server/currencies/fetch", () => ({
@@ -8,12 +13,22 @@ vi.mock("@/server/currencies/fetch", () => ({
     { alphabetic_code: "USD" },
     { alphabetic_code: "EUR" },
     { alphabetic_code: "GBP" },
+    { alphabetic_code: "KWD" },
   ]),
+}));
+
+vi.mock("@/server/symbols/validate", () => ({
+  validateSymbolsBatch: validateSymbolsBatchMock,
 }));
 
 describe("parsePositionsCSV", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    validateSymbolsBatchMock.mockResolvedValue({
+      valid: true,
+      results: new Map(),
+      errors: [],
+    });
   });
 
   it("should return error when CSV has less than 2 lines", async () => {
@@ -182,6 +197,66 @@ Apple Inc,10,USD,120`;
     expect(result.success).toBe(true);
     expect(result.positions).toHaveLength(1);
     expect(result.positions[0].capital_gains_tax_rate).toBe(0.26);
+  });
+
+  it("should normalize GBp quote-unit values for symbol-backed rows", async () => {
+    validateSymbolsBatchMock.mockResolvedValue({
+      valid: true,
+      results: new Map([
+        [
+          "BP.L",
+          {
+            valid: true,
+            normalized: "BP.L",
+            currency: "GBP",
+          },
+        ],
+      ]),
+      errors: [],
+    });
+
+    const csv = `name,quantity,currency,unit_value,cost_basis_per_unit,symbol
+BP p.l.c.,10,GBp,524.4,500,BP.L`;
+
+    const result = await parsePositionsCSV(csv);
+
+    expect(result.success).toBe(true);
+    expect(result.positions[0].currency).toBe("GBP");
+    expect(result.positions[0].unit_value).toBeCloseTo(5.244, 10);
+    expect(result.positions[0].cost_basis_per_unit).toBeCloseTo(5, 10);
+    expect(result.warnings?.[0]).toContain(
+      "Normalized quote unit GBp for BP.L to GBP",
+    );
+  });
+
+  it("should normalize KWF quote-unit values for symbol-backed rows", async () => {
+    validateSymbolsBatchMock.mockResolvedValue({
+      valid: true,
+      results: new Map([
+        [
+          "NBK.KW",
+          {
+            valid: true,
+            normalized: "NBK.KW",
+            currency: "KWD",
+          },
+        ],
+      ]),
+      errors: [],
+    });
+
+    const csv = `name,quantity,currency,unit_value,cost_basis_per_unit,symbol
+National Bank of Kuwait,100,KWF,838,800,NBK.KW`;
+
+    const result = await parsePositionsCSV(csv);
+
+    expect(result.success).toBe(true);
+    expect(result.positions[0].currency).toBe("KWD");
+    expect(result.positions[0].unit_value).toBeCloseTo(0.838, 10);
+    expect(result.positions[0].cost_basis_per_unit).toBeCloseTo(0.8, 10);
+    expect(result.warnings?.[0]).toContain(
+      "Normalized quote unit KWF for NBK.KW to KWD",
+    );
   });
 
   it("should return validation error for invalid capital gains tax rate", async () => {

--- a/lib/import/positions/parse-csv.test.ts
+++ b/lib/import/positions/parse-csv.test.ts
@@ -259,6 +259,36 @@ National Bank of Kuwait,100,KWF,838,800,NBK.KW`;
     );
   });
 
+  it("should reject quote-unit amounts when the symbol resolves to a different currency", async () => {
+    validateSymbolsBatchMock.mockResolvedValue({
+      valid: true,
+      results: new Map([
+        [
+          "AAPL",
+          {
+            valid: true,
+            normalized: "AAPL",
+            currency: "USD",
+          },
+        ],
+      ]),
+      errors: [],
+    });
+
+    const csv = `name,quantity,currency,unit_value,cost_basis_per_unit,symbol
+Wrong symbol,10,GBp,524.4,500,AAPL`;
+
+    const result = await parsePositionsCSV(csv);
+
+    expect(result.success).toBe(false);
+    expect(result.positions[0].currency).toBe("GBp");
+    expect(result.positions[0].unit_value).toBe(524.4);
+    expect(result.positions[0].cost_basis_per_unit).toBe(500);
+    expect(result.errors?.[0]).toBe(
+      'Row 1: Quote unit GBp normalizes to GBP, but symbol lookup "AAPL" uses USD. Check the symbol or currency column before importing.',
+    );
+  });
+
   it("should return validation error for invalid capital gains tax rate", async () => {
     const csv = `name,quantity,currency,unit_value,capital_gains_tax_rate
 Apple Inc,10,USD,120,120`;

--- a/lib/import/positions/parse-csv.ts
+++ b/lib/import/positions/parse-csv.ts
@@ -11,6 +11,8 @@ import {
   splitCSVRecords,
 } from "@/lib/import/shared/csv-parser-utils";
 import { parseNumberStrict } from "@/lib/import/shared/number-parser";
+import { normalizeProviderQuoteUnit } from "@/server/market-data/quote-units";
+import { fetchCurrencies } from "@/server/currencies/fetch";
 
 import {
   buildPositionColumnMap,
@@ -18,8 +20,6 @@ import {
 } from "./header-mapper";
 import { mapCategory } from "./category-mapper";
 import { normalizePositionsArray, validatePositionsArray } from "./validation";
-
-import { fetchCurrencies } from "@/server/currencies/fetch";
 
 import type { PositionImportRow, PositionImportResult } from "./types";
 
@@ -86,6 +86,21 @@ function inferCurrencyColumnIndex(
   }
 
   return bestIndex;
+}
+
+function normalizeImportedCurrency(rawCurrency: string | undefined): string {
+  const trimmedCurrency = (rawCurrency || "").trim();
+  if (!trimmedCurrency) return "";
+
+  const quoteUnit = normalizeProviderQuoteUnit(trimmedCurrency);
+
+  if (quoteUnit.success && quoteUnit.data.quoteToCurrencyRate !== 1) {
+    // Preserve provider quote-unit spelling such as GBp. Uppercasing too early
+    // would make GBp indistinguishable from ISO GBP before amount scaling.
+    return trimmedCurrency;
+  }
+
+  return trimmedCurrency.toUpperCase();
 }
 
 /**
@@ -199,7 +214,7 @@ export async function parsePositionsCSV(
       const position: PositionImportRow = {
         name: nameValue,
         category_id: mapCategory(categoryRaw),
-        currency: (currencyRaw || "").trim().toUpperCase(),
+        currency: normalizeImportedCurrency(currencyRaw),
         quantity: parseNumberStrict(values[columnMap.get("quantity")!]),
         unit_value: isNaN(parsedUnitValue) ? null : parsedUnitValue,
         cost_basis_per_unit: isNaN(parsedCostBasis) ? null : parsedCostBasis,

--- a/lib/import/positions/parse-csv.ts
+++ b/lib/import/positions/parse-csv.ts
@@ -238,6 +238,7 @@ export async function parsePositionsCSV(
     const {
       positions: normalizedPositions,
       warnings,
+      errors: normalizationErrors,
       symbolValidationResults,
     } = await normalizePositionsArray(parsedPositions);
 
@@ -246,19 +247,20 @@ export async function parsePositionsCSV(
       normalizedPositions,
       symbolValidationResults,
     );
+    const errors = [...normalizationErrors, ...validationErrors];
 
     // Convert Map to Record for JSON-friendly shape
     const symbolValidation = symbolValidationResults
       ? Object.fromEntries(symbolValidationResults)
       : undefined;
 
-    if (validationErrors.length > 0) {
+    if (errors.length > 0) {
       // Validation failed: return parsed positions alongside errors so user can review/fix
       return {
         success: false,
         positions: normalizedPositions,
         warnings: warnings && warnings.length ? warnings : undefined,
-        errors: validationErrors,
+        errors,
         symbolValidation,
         supportedCurrencies,
       };

--- a/lib/import/positions/validation.ts
+++ b/lib/import/positions/validation.ts
@@ -1,4 +1,5 @@
 import { fetchCurrencies } from "@/server/currencies/fetch";
+import { normalizeProviderQuoteUnit } from "@/server/market-data/quote-units";
 import {
   validateSymbolsBatch,
   type SymbolValidationResult,
@@ -8,6 +9,65 @@ import { normalizeCapitalGainsTaxRateToDecimal } from "@/lib/capital-gains-tax-r
 // Categories are normalized via mapper upstream; no need to validate codes here
 
 import type { PositionImportRow } from "./types";
+
+function scaleNullableAmount(
+  amount: number | null,
+  quoteToCurrencyRate: number,
+): number | null {
+  return amount == null ? null : amount * quoteToCurrencyRate;
+}
+
+function normalizeSymbolBackedQuoteUnit(
+  position: PositionImportRow,
+  symbolCurrency: string,
+): { normalized: boolean; warning?: string } {
+  // Broker exports can use provider quote units for listed securities
+  // (GBX/GBp pence, KWF fils). If the symbol confirms the matching ISO
+  // accounting currency, scale per-unit amounts before validation/persistence.
+  const quoteUnit = normalizeProviderQuoteUnit(position.currency);
+
+  if (!quoteUnit.success) {
+    return { normalized: false };
+  }
+
+  if (
+    quoteUnit.data.currency !== symbolCurrency ||
+    quoteUnit.data.quoteToCurrencyRate === 1
+  ) {
+    return { normalized: false };
+  }
+
+  const originalCurrency = position.currency;
+  const scaledFields: string[] = [];
+
+  if (position.unit_value != null) {
+    position.unit_value = scaleNullableAmount(
+      position.unit_value,
+      quoteUnit.data.quoteToCurrencyRate,
+    );
+    scaledFields.push("unit value");
+  }
+
+  if (position.cost_basis_per_unit != null) {
+    position.cost_basis_per_unit = scaleNullableAmount(
+      position.cost_basis_per_unit,
+      quoteUnit.data.quoteToCurrencyRate,
+    );
+    scaledFields.push("cost basis");
+  }
+
+  position.currency = symbolCurrency;
+
+  const scaledSuffix =
+    scaledFields.length > 0
+      ? ` and scaled ${scaledFields.join(" and ")} by ${quoteUnit.data.quoteToCurrencyRate}`
+      : "";
+
+  return {
+    normalized: true,
+    warning: `Normalized quote unit ${originalCurrency} for ${position.symbolLookup} to ${symbolCurrency}${scaledSuffix}`,
+  };
+}
 
 /**
  * Validates an array of positions with optional pre-validated symbol results
@@ -77,7 +137,7 @@ export async function validatePositionsArray(
 
 /**
  * Normalize positions using symbol metadata (currency and normalized symbol id)
- * - Adjusts currency to the symbol's native trading currency
+ * - Adjusts currency to the symbol's normalized ISO accounting currency
  * - Normalizes symbol id when possible
  * - Returns warnings describing adjustments made
  */
@@ -130,10 +190,21 @@ export async function normalizePositionsArray(
     if (!v) return;
 
     if (v.currency && h.currency !== v.currency) {
-      warnings.push(
-        `Adjusted currency for ${h.symbolLookup} from ${h.currency} to ${v.currency}`,
+      const quoteUnitNormalization = normalizeSymbolBackedQuoteUnit(
+        h,
+        v.currency,
       );
-      h.currency = v.currency;
+
+      if (quoteUnitNormalization.normalized) {
+        if (quoteUnitNormalization.warning) {
+          warnings.push(quoteUnitNormalization.warning);
+        }
+      } else {
+        warnings.push(
+          `Adjusted accounting currency for ${h.symbolLookup} from ${h.currency} to ${v.currency}`,
+        );
+        h.currency = v.currency;
+      }
     }
 
     if (v.normalized && v.normalized !== h.symbolLookup) {
@@ -237,7 +308,7 @@ export function validatePosition(
  * Validates symbol currency matches CSV currency
  * @param position - The position to validate
  * @param rowNumber - The row number for error reporting
- * @param symbolCurrency - The currency from symbol validation
+ * @param symbolCurrency - The normalized ISO accounting currency from symbol validation
  * @returns Array of validation errors (empty if valid)
  */
 export function validateSymbolCurrency(
@@ -247,7 +318,7 @@ export function validateSymbolCurrency(
 ): string[] {
   if (symbolCurrency && symbolCurrency !== position.currency) {
     return [
-      `Row ${rowNumber}: Symbol lookup "${position.symbolLookup}" uses ${symbolCurrency} currency, but CSV specifies ${position.currency}. Please use ${symbolCurrency} for this symbol.`,
+      `Row ${rowNumber}: Symbol lookup "${position.symbolLookup}" uses ${symbolCurrency} as its normalized ISO accounting currency, but CSV specifies ${position.currency}. Please use ${symbolCurrency} for this symbol.`,
     ];
   }
   return [];

--- a/lib/import/positions/validation.ts
+++ b/lib/import/positions/validation.ts
@@ -17,24 +17,34 @@ function scaleNullableAmount(
   return amount == null ? null : amount * quoteToCurrencyRate;
 }
 
+type SymbolBackedQuoteUnitNormalization =
+  | { status: "not_applicable" }
+  | { status: "normalized"; warning: string }
+  | { status: "mismatched_quote_unit"; error: string };
+
 function normalizeSymbolBackedQuoteUnit(
   position: PositionImportRow,
   symbolCurrency: string,
-): { normalized: boolean; warning?: string } {
+  rowNumber: number,
+): SymbolBackedQuoteUnitNormalization {
   // Broker exports can use provider quote units for listed securities
   // (GBX/GBp pence, KWF fils). If the symbol confirms the matching ISO
   // accounting currency, scale per-unit amounts before validation/persistence.
   const quoteUnit = normalizeProviderQuoteUnit(position.currency);
 
   if (!quoteUnit.success) {
-    return { normalized: false };
+    return { status: "not_applicable" };
   }
 
-  if (
-    quoteUnit.data.currency !== symbolCurrency ||
-    quoteUnit.data.quoteToCurrencyRate === 1
-  ) {
-    return { normalized: false };
+  if (quoteUnit.data.quoteToCurrencyRate === 1) {
+    return { status: "not_applicable" };
+  }
+
+  if (quoteUnit.data.currency !== symbolCurrency) {
+    return {
+      status: "mismatched_quote_unit",
+      error: `Row ${rowNumber}: Quote unit ${position.currency} normalizes to ${quoteUnit.data.currency}, but symbol lookup "${position.symbolLookup}" uses ${symbolCurrency}. Check the symbol or currency column before importing.`,
+    };
   }
 
   const originalCurrency = position.currency;
@@ -64,7 +74,7 @@ function normalizeSymbolBackedQuoteUnit(
       : "";
 
   return {
-    normalized: true,
+    status: "normalized",
     warning: `Normalized quote unit ${originalCurrency} for ${position.symbolLookup} to ${symbolCurrency}${scaledSuffix}`,
   };
 }
@@ -146,9 +156,11 @@ export async function normalizePositionsArray(
 ): Promise<{
   positions: PositionImportRow[];
   warnings: string[];
+  errors: string[];
   symbolValidationResults?: Map<string, SymbolValidationResult>;
 }> {
   const warnings: string[] = [];
+  const errors: string[] = [];
 
   // Clone rows to avoid mutating input
   const cloned = rows.map((h) => ({ ...h }));
@@ -179,12 +191,12 @@ export async function normalizePositionsArray(
     .map((r) => (r.symbolLookup || "").trim())
     .filter(Boolean);
   if (symbols.length === 0) {
-    return { positions: cloned, warnings };
+    return { positions: cloned, warnings, errors };
   }
 
   const batch = await validateSymbolsBatch(symbols);
 
-  cloned.forEach((h) => {
+  cloned.forEach((h, index) => {
     if (!h.symbolLookup) return;
     const v = batch.results.get(h.symbolLookup);
     if (!v) return;
@@ -193,12 +205,16 @@ export async function normalizePositionsArray(
       const quoteUnitNormalization = normalizeSymbolBackedQuoteUnit(
         h,
         v.currency,
+        index + 1,
       );
 
-      if (quoteUnitNormalization.normalized) {
-        if (quoteUnitNormalization.warning) {
-          warnings.push(quoteUnitNormalization.warning);
-        }
+      if (quoteUnitNormalization.status === "normalized") {
+        warnings.push(quoteUnitNormalization.warning);
+      } else if (quoteUnitNormalization.status === "mismatched_quote_unit") {
+        // Do not rewrite the row when a quote unit points at a different ISO
+        // currency than the symbol. Keeping the original input visible prevents
+        // pence/fils amounts from being treated as an unrelated major currency.
+        errors.push(quoteUnitNormalization.error);
       } else {
         warnings.push(
           `Adjusted accounting currency for ${h.symbolLookup} from ${h.currency} to ${v.currency}`,
@@ -216,6 +232,7 @@ export async function normalizePositionsArray(
   return {
     positions: cloned,
     warnings,
+    errors,
     symbolValidationResults: batch.results,
   };
 }

--- a/server/analysis/projected-income/symbol.test.ts
+++ b/server/analysis/projected-income/symbol.test.ts
@@ -235,6 +235,7 @@ describe("symbol projected income", () => {
               createDividendEvent({
                 event_date: "2023-12-15",
                 gross_amount: 2,
+                currency: "GBP",
               }),
             ],
           },
@@ -253,6 +254,7 @@ describe("symbol projected income", () => {
     );
 
     expect(result.projectedIncome.success).toBe(true);
+    expect(result.projectedIncome.currency).toBe("GBP");
     expect(result.projectedIncome.data?.[11]?.income).toBeCloseTo(2, 6);
     expect(
       result.projectedIncome.data?.reduce(

--- a/server/dividends/fetch.test.ts
+++ b/server/dividends/fetch.test.ts
@@ -140,23 +140,52 @@ function createFakeServiceClient(state: FakeDividendState) {
 
 function mockResolvedSymbol() {
   resolveSymbolsBatchMock.mockResolvedValue({
-    byInput: new Map([["sym-1", { canonicalId: "sym-1" }]]),
-    byCanonicalId: new Map([["sym-1", { providerAlias: "TEST" }]]),
+    byInput: new Map([
+      [
+        "sym-1",
+        { canonicalId: "sym-1", currency: "USD", quoteToCurrencyRate: 1 },
+      ],
+    ]),
+    byCanonicalId: new Map([
+      [
+        "sym-1",
+        { providerAlias: "TEST", currency: "USD", quoteToCurrencyRate: 1 },
+      ],
+    ]),
   });
 }
 
 function mockResolvedSymbols(
-  symbols: Array<{ input: string; canonicalId: string; providerAlias: string }>,
+  symbols: Array<{
+    input: string;
+    canonicalId: string;
+    providerAlias: string;
+    currency?: string;
+    quoteToCurrencyRate?: number;
+  }>,
 ) {
   resolveSymbolsBatchMock.mockResolvedValue({
     byInput: new Map(
-      symbols.map(({ canonicalId, input }) => [input, { canonicalId }]),
+      symbols.map(({ canonicalId, currency, input, quoteToCurrencyRate }) => [
+        input,
+        {
+          canonicalId,
+          currency: currency ?? "USD",
+          quoteToCurrencyRate: quoteToCurrencyRate ?? 1,
+        },
+      ]),
     ),
     byCanonicalId: new Map(
-      symbols.map(({ canonicalId, providerAlias }) => [
-        canonicalId,
-        { providerAlias },
-      ]),
+      symbols.map(
+        ({ canonicalId, currency, providerAlias, quoteToCurrencyRate }) => [
+          canonicalId,
+          {
+            providerAlias,
+            currency: currency ?? "USD",
+            quoteToCurrencyRate: quoteToCurrencyRate ?? 1,
+          },
+        ],
+      ),
     ),
   });
 }
@@ -405,6 +434,140 @@ describe("fetchDividends", () => {
         pays_dividends: true,
         last_dividend_date: "2025-12-15",
       }),
+    );
+  });
+
+  it("normalizes UK chart dividend event amounts to GBP", async () => {
+    mockResolvedSymbols([
+      {
+        input: "bp-symbol",
+        canonicalId: "bp-symbol",
+        providerAlias: "BP.L",
+        currency: "GBP",
+        quoteToCurrencyRate: 0.01,
+      },
+    ]);
+    const state: FakeDividendState = {
+      events: [],
+      summaries: [],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+    yahooQuoteSummaryMock.mockRejectedValue(
+      new Error("No fundamentals data found for symbol: BP.L"),
+    );
+    yahooChartMock.mockResolvedValue({
+      events: {
+        dividends: [
+          {
+            date: new Date("2025-12-15T00:00:00.000Z"),
+            amount: 6.1780996,
+          },
+        ],
+      },
+      meta: { currency: "GBp" },
+    });
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "bp-symbol" }]);
+    const event = result.get("bp-symbol")?.events[0];
+
+    expect(event?.currency).toBe("GBP");
+    expect(event?.gross_amount).toBeCloseTo(0.061780996, 10);
+
+    const eventUpsert = state.upserts.find(
+      (upsert) => upsert.table === "dividend_events",
+    );
+    const payloadEvent = eventUpsert?.payload[0] as DividendEvent | undefined;
+    expect(payloadEvent?.currency).toBe("GBP");
+    expect(payloadEvent?.gross_amount).toBeCloseTo(0.061780996, 10);
+  });
+
+  it("normalizes Kuwait chart dividend event amounts to KWD", async () => {
+    mockResolvedSymbols([
+      {
+        input: "nbk-symbol",
+        canonicalId: "nbk-symbol",
+        providerAlias: "NBK.KW",
+        currency: "KWD",
+        quoteToCurrencyRate: 0.001,
+      },
+    ]);
+    const state: FakeDividendState = {
+      events: [],
+      summaries: [],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+    yahooQuoteSummaryMock.mockRejectedValue(
+      new Error("No fundamentals data found for symbol: NBK.KW"),
+    );
+    yahooChartMock.mockResolvedValue({
+      events: {
+        dividends: [
+          {
+            date: new Date("2025-12-15T00:00:00.000Z"),
+            amount: 35,
+          },
+        ],
+      },
+      meta: { currency: "KWF" },
+    });
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "nbk-symbol" }]);
+    const event = result.get("nbk-symbol")?.events[0];
+
+    expect(event?.currency).toBe("KWD");
+    expect(event?.gross_amount).toBeCloseTo(0.035, 10);
+  });
+
+  it("does not quote-unit scale summary dividend amounts", async () => {
+    mockResolvedSymbols([
+      {
+        input: "bp-symbol",
+        canonicalId: "bp-symbol",
+        providerAlias: "BP.L",
+        currency: "GBP",
+        quoteToCurrencyRate: 0.01,
+      },
+    ]);
+    const state: FakeDividendState = {
+      events: [],
+      summaries: [],
+      upserts: [],
+    };
+    createServiceClientMock.mockReturnValue(createFakeServiceClient(state));
+    yahooQuoteSummaryMock.mockResolvedValue({
+      summaryDetail: {
+        dividendRate: 1.2,
+        trailingAnnualDividendRate: 1.1,
+        dividendYield: 0.04,
+      },
+      calendarEvents: {},
+    });
+    yahooChartMock.mockResolvedValue({
+      events: {
+        dividends: [
+          {
+            date: new Date("2025-12-15T00:00:00.000Z"),
+            amount: 6.1780996,
+          },
+        ],
+      },
+      meta: { currency: "GBp" },
+    });
+
+    const { fetchDividends } = await import("./fetch");
+    const result = await fetchDividends([{ symbolId: "bp-symbol" }]);
+    const summary = result.get("bp-symbol")?.summary;
+
+    expect(summary?.forward_annual_dividend).toBe(1.2);
+    expect(summary?.trailing_ttm_dividend).toBe(1.1);
+    expect(summary?.dividend_yield).toBe(0.04);
+    expect(result.get("bp-symbol")?.events[0]?.gross_amount).toBeCloseTo(
+      0.061780996,
+      10,
     );
   });
 

--- a/server/dividends/fetch.ts
+++ b/server/dividends/fetch.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { yahooFinance } from "@/server/yahoo-finance/client";
 import { createServiceClient } from "@/supabase/service";
+import { normalizeQuoteToCurrencyRate } from "@/server/market-data/quote-units";
 import { resolveSymbolsBatch } from "@/server/symbols/resolve";
 import {
   extractStatusCode,
@@ -287,13 +288,18 @@ export async function fetchDividends(
     const fetchPromises = missingCanonicalIds.map(
       async (symbolId): Promise<FetchedDividendResult> => {
         const resolution = byCanonicalId.get(symbolId);
-        const yahooTicker = resolution?.providerAlias;
-        if (!yahooTicker) {
+        if (!resolution?.providerAlias) {
           console.error(
             `Failed to fetch dividends for ${symbolId}: missing Yahoo ticker alias.`,
           );
           return { symbolId, events: [], summary: null as Dividend | null };
         }
+
+        const yahooTicker = resolution.providerAlias;
+        const dividendCurrency = resolution.currency;
+        const quoteToCurrencyRate = normalizeQuoteToCurrencyRate(
+          resolution.quoteToCurrencyRate,
+        );
 
         try {
           const [summaryResult, chartResult] = await Promise.allSettled([
@@ -323,12 +329,16 @@ export async function fetchDividends(
           const events: DividendEvent[] = [];
           if (chart?.events?.dividends) {
             chart.events.dividends.forEach((dividend) => {
+              // Yahoo chart dividend amounts use the same provider quote unit
+              // as chart prices. The symbol row already stores the normalized
+              // ISO currency and multiplier, so cache dividend events in that
+              // accounting currency instead of leaking GBp/KWF-style units.
               events.push({
                 id: uuidv4(),
                 symbol_id: symbolId,
                 event_date: formatUTCDateKey(dividend.date),
-                gross_amount: dividend.amount,
-                currency: chart.meta.currency || "USD",
+                gross_amount: dividend.amount * quoteToCurrencyRate,
+                currency: dividendCurrency,
                 source: "yahoo",
                 created_at: new Date().toISOString(),
               });
@@ -346,6 +356,9 @@ export async function fetchDividends(
 
           if (hasDividendData) {
             const now = new Date().toISOString();
+            // Do not quote-unit scale summaryDetail dividend amounts here.
+            // Yahoo's summary fields are independent from chart events and can
+            // already be reported as major-currency annual values.
             const summaryData: Dividend = {
               symbol_id: symbolId,
               forward_annual_dividend:

--- a/server/market-data/quote-units.test.ts
+++ b/server/market-data/quote-units.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeProviderQuoteUnit } from "./quote-units";
+
+describe("normalizeProviderQuoteUnit", () => {
+  it.each([
+    ["GBp", "GBP", 0.01],
+    ["GBX", "GBP", 0.01],
+    ["KWF", "KWD", 0.001],
+    ["USX", "USD", 0.01],
+  ])("normalizes provider quote unit %s", (quoteCurrency, currency, rate) => {
+    const result = normalizeProviderQuoteUnit(quoteCurrency);
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        quoteCurrency,
+        currency,
+        quoteToCurrencyRate: rate,
+      },
+    });
+  });
+
+  it("keeps ISO currency codes as major currency units", () => {
+    const result = normalizeProviderQuoteUnit("usd");
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        quoteCurrency: "usd",
+        currency: "USD",
+        quoteToCurrencyRate: 1,
+      },
+    });
+  });
+
+  it("returns a clear error for unsupported provider quote units", () => {
+    const result = normalizeProviderQuoteUnit("XAUOZ");
+
+    expect(result).toEqual({
+      success: false,
+      code: "UNSUPPORTED_QUOTE_UNIT",
+      message: 'Unsupported provider quote currency "XAUOZ".',
+    });
+  });
+});

--- a/server/market-data/quote-units.test.ts
+++ b/server/market-data/quote-units.test.ts
@@ -7,7 +7,6 @@ describe("normalizeProviderQuoteUnit", () => {
     ["GBp", "GBP", 0.01],
     ["GBX", "GBP", 0.01],
     ["KWF", "KWD", 0.001],
-    ["USX", "USD", 0.01],
   ])("normalizes provider quote unit %s", (quoteCurrency, currency, rate) => {
     const result = normalizeProviderQuoteUnit(quoteCurrency);
 

--- a/server/market-data/quote-units.ts
+++ b/server/market-data/quote-units.ts
@@ -1,0 +1,97 @@
+export interface NormalizedQuoteUnit {
+  quoteCurrency: string;
+  currency: string;
+  quoteToCurrencyRate: number;
+}
+
+export type NormalizeQuoteUnitResult =
+  | {
+      success: true;
+      data: NormalizedQuoteUnit;
+    }
+  | {
+      success: false;
+      code: "INVALID_QUOTE_UNIT" | "UNSUPPORTED_QUOTE_UNIT";
+      message: string;
+    };
+
+const QUOTE_UNIT_OVERRIDES: Record<
+  string,
+  Pick<NormalizedQuoteUnit, "currency" | "quoteToCurrencyRate">
+> = {
+  // Keep this as a small provider-unit registry. Once it grows beyond a handful
+  // of deterministic Yahoo quote units, move the mappings to an admin-managed
+  // table while keeping symbols.quote_to_currency_rate as the persisted truth.
+  GBp: { currency: "GBP", quoteToCurrencyRate: 0.01 },
+  GBX: { currency: "GBP", quoteToCurrencyRate: 0.01 },
+  KWF: { currency: "KWD", quoteToCurrencyRate: 0.001 },
+  USX: { currency: "USD", quoteToCurrencyRate: 0.01 },
+};
+
+const ISO_CURRENCY_PATTERN = /^[A-Z]{3}$/;
+
+export function normalizeQuoteToCurrencyRate(
+  rate: number | null | undefined,
+): number {
+  // DB rows should always have a positive multiplier, but provider-facing code
+  // uses this guard so a malformed fixture or stale row cannot corrupt values.
+  return typeof rate === "number" && Number.isFinite(rate) && rate > 0
+    ? rate
+    : 1;
+}
+
+export function normalizeProviderQuoteUnit(
+  rawQuoteCurrency: string | null | undefined,
+): NormalizeQuoteUnitResult {
+  const quoteCurrency = rawQuoteCurrency?.trim();
+
+  if (!quoteCurrency) {
+    return {
+      success: false,
+      code: "INVALID_QUOTE_UNIT",
+      message: "Missing provider quote currency.",
+    };
+  }
+
+  const exactOverride = QUOTE_UNIT_OVERRIDES[quoteCurrency];
+  if (exactOverride) {
+    return {
+      success: true,
+      data: {
+        quoteCurrency,
+        currency: exactOverride.currency,
+        quoteToCurrencyRate: exactOverride.quoteToCurrencyRate,
+      },
+    };
+  }
+
+  const normalizedCurrency = quoteCurrency.toUpperCase();
+  const uppercaseOverride = QUOTE_UNIT_OVERRIDES[normalizedCurrency];
+  if (uppercaseOverride) {
+    return {
+      success: true,
+      data: {
+        quoteCurrency,
+        currency: uppercaseOverride.currency,
+        quoteToCurrencyRate: uppercaseOverride.quoteToCurrencyRate,
+      },
+    };
+  }
+
+  if (ISO_CURRENCY_PATTERN.test(normalizedCurrency)) {
+    return {
+      success: true,
+      data: {
+        quoteCurrency,
+        currency: normalizedCurrency,
+        quoteToCurrencyRate: 1,
+      },
+    };
+  }
+
+  return {
+    success: false,
+    code: "UNSUPPORTED_QUOTE_UNIT",
+    message: `Unsupported provider quote currency "${quoteCurrency}".`,
+  };
+}

--- a/server/market-data/quote-units.ts
+++ b/server/market-data/quote-units.ts
@@ -25,7 +25,6 @@ const QUOTE_UNIT_OVERRIDES: Record<
   GBp: { currency: "GBP", quoteToCurrencyRate: 0.01 },
   GBX: { currency: "GBP", quoteToCurrencyRate: 0.01 },
   KWF: { currency: "KWD", quoteToCurrencyRate: 0.001 },
-  USX: { currency: "USD", quoteToCurrencyRate: 0.01 },
 };
 
 const ISO_CURRENCY_PATTERN = /^[A-Z]{3}$/;

--- a/server/news/fetch.ts
+++ b/server/news/fetch.ts
@@ -23,6 +23,11 @@ type EnrichedNewsArticle = NewsArticle & {
   related_symbols: Array<{ id: string; ticker: string | null }>;
 };
 
+type NewsSymbolMetadata = {
+  providerAlias: string;
+  displayTicker: string | null;
+};
+
 // Cache duration: 30 minutes
 const CACHE_DURATION_MS = 30 * 60 * 1000;
 
@@ -62,7 +67,15 @@ export async function fetchNewsForSymbols(
     const canonicalIdSet = new Set(canonicalIds);
 
     // Start with batch-resolved metadata, then extend as we discover related symbols
-    const canonicalMeta = new Map(byCanonicalId);
+    const canonicalMeta = new Map<string, NewsSymbolMetadata>(
+      Array.from(byCanonicalId, ([canonicalId, meta]) => [
+        canonicalId,
+        {
+          providerAlias: meta.providerAlias,
+          displayTicker: meta.displayTicker,
+        },
+      ]),
+    );
 
     const supabase = createServiceClient();
     const cacheThreshold = new Date(Date.now() - CACHE_DURATION_MS);
@@ -159,8 +172,6 @@ export async function fetchNewsForSymbols(
                 canonicalMeta.set(existingResolution.canonicalId, {
                   providerAlias: existingResolution.providerAlias,
                   displayTicker: existingResolution.displayTicker,
-                  currency: existingResolution.currency,
-                  quoteToCurrencyRate: existingResolution.quoteToCurrencyRate,
                 });
               }
               continue;
@@ -177,8 +188,6 @@ export async function fetchNewsForSymbols(
                   canonicalMeta.set(cached.canonicalId, {
                     providerAlias: cached.displayTicker,
                     displayTicker: cached.displayTicker,
-                    currency: "USD",
-                    quoteToCurrencyRate: 1,
                   });
                 }
               }
@@ -201,8 +210,6 @@ export async function fetchNewsForSymbols(
                 canonicalMeta.set(relatedCanonical, {
                   providerAlias: relatedDisplayTicker ?? trimmed,
                   displayTicker: relatedDisplayTicker,
-                  currency: relatedResolved?.symbol?.currency ?? "USD",
-                  quoteToCurrencyRate: 1,
                 });
               }
             }

--- a/server/news/fetch.ts
+++ b/server/news/fetch.ts
@@ -159,6 +159,8 @@ export async function fetchNewsForSymbols(
                 canonicalMeta.set(existingResolution.canonicalId, {
                   providerAlias: existingResolution.providerAlias,
                   displayTicker: existingResolution.displayTicker,
+                  currency: existingResolution.currency,
+                  quoteToCurrencyRate: existingResolution.quoteToCurrencyRate,
                 });
               }
               continue;
@@ -175,6 +177,8 @@ export async function fetchNewsForSymbols(
                   canonicalMeta.set(cached.canonicalId, {
                     providerAlias: cached.displayTicker,
                     displayTicker: cached.displayTicker,
+                    currency: "USD",
+                    quoteToCurrencyRate: 1,
                   });
                 }
               }
@@ -197,6 +201,8 @@ export async function fetchNewsForSymbols(
                 canonicalMeta.set(relatedCanonical, {
                   providerAlias: relatedDisplayTicker ?? trimmed,
                   displayTicker: relatedDisplayTicker,
+                  currency: relatedResolved?.symbol?.currency ?? "USD",
+                  quoteToCurrencyRate: 1,
                 });
               }
             }
@@ -306,17 +312,12 @@ export async function fetchNewsForSymbols(
     );
 
     const canonicalIdToTicker = new Map<string, string>();
-    canonicalMeta.forEach(
-      (
-        meta: { providerAlias: string; displayTicker: string | null },
-        canonicalId: string,
-      ) => {
-        const ticker = meta.displayTicker ?? meta.providerAlias;
-        if (ticker) {
-          canonicalIdToTicker.set(canonicalId, ticker);
-        }
-      },
-    );
+    canonicalMeta.forEach((meta, canonicalId) => {
+      const ticker = meta.displayTicker ?? meta.providerAlias;
+      if (ticker) {
+        canonicalIdToTicker.set(canonicalId, ticker);
+      }
+    });
 
     const enrichedArticles = uniqueArticles.map((article) => ({
       ...article,

--- a/server/quotes/fetch.test.ts
+++ b/server/quotes/fetch.test.ts
@@ -202,14 +202,18 @@ function mockSymbolResolution(options?: {
   lookup?: string;
   canonicalId?: string;
   providerAlias?: string;
+  quoteToCurrencyRate?: number;
 }) {
   const lookup = options?.lookup ?? "sym-1";
   const canonicalId = options?.canonicalId ?? "sym-1";
   const providerAlias = options?.providerAlias ?? "AAPL";
+  const quoteToCurrencyRate = options?.quoteToCurrencyRate ?? 1;
 
   resolveSymbolsBatchMock.mockResolvedValue({
-    byInput: new Map([[lookup, { canonicalId }]]),
-    byCanonicalId: new Map([[canonicalId, { providerAlias }]]),
+    byInput: new Map([[lookup, { canonicalId, quoteToCurrencyRate }]]),
+    byCanonicalId: new Map([
+      [canonicalId, { providerAlias, quoteToCurrencyRate }],
+    ]),
   });
 }
 
@@ -350,6 +354,141 @@ describe("fetchQuotes", () => {
         last_quote_at: "2026-02-14T00:00:00.000Z",
       },
     ]);
+  });
+
+  it("normalizes GBp chart prices before caching and returning", async () => {
+    vi.setSystemTime(new Date("2026-02-15T23:00:00.000Z"));
+
+    const { client, state } = createSupabaseStub([]);
+    createServiceClientMock.mockResolvedValue(client);
+    mockSymbolResolution({
+      lookup: "BP.L",
+      canonicalId: "bp-symbol",
+      providerAlias: "BP.L",
+      quoteToCurrencyRate: 0.01,
+    });
+    yahooChartMock.mockResolvedValue({
+      quotes: [
+        {
+          date: new Date("2026-02-14T00:00:00.000Z"),
+          close: 524.4,
+          adjclose: 523.2,
+        },
+      ],
+    });
+
+    const { fetchQuotes } = await import("./fetch");
+
+    const result = await fetchQuotes(
+      [
+        {
+          symbolLookup: "BP.L",
+          date: new Date("2026-02-15T00:00:00.000Z"),
+        },
+      ],
+      { staleGuardDays: 0 },
+    );
+
+    expect(result.get("bp-symbol|2026-02-15")).toBeCloseTo(5.244, 10);
+    expect(result.get("BP.L|2026-02-15")).toBeCloseTo(5.244, 10);
+    expect(state.upsertCalls).toHaveLength(1);
+
+    const row = state.upsertCalls[0]?.rows[0];
+    expect(row).toMatchObject({
+      symbol_id: "bp-symbol",
+      date: "2026-02-14",
+    });
+    expect(row?.close_price).toBeCloseTo(5.244, 10);
+    expect(row?.adjusted_close_price).toBeCloseTo(5.232, 10);
+  });
+
+  it("normalizes KWF chart prices before caching and returning", async () => {
+    vi.setSystemTime(new Date("2026-02-15T23:00:00.000Z"));
+
+    const { client, state } = createSupabaseStub([]);
+    createServiceClientMock.mockResolvedValue(client);
+    mockSymbolResolution({
+      lookup: "NBK.KW",
+      canonicalId: "nbk-symbol",
+      providerAlias: "NBK.KW",
+      quoteToCurrencyRate: 0.001,
+    });
+    yahooChartMock.mockResolvedValue({
+      quotes: [
+        {
+          date: new Date("2026-02-14T00:00:00.000Z"),
+          close: 838,
+          adjclose: 837,
+        },
+      ],
+    });
+
+    const { fetchQuotes } = await import("./fetch");
+
+    const result = await fetchQuotes(
+      [
+        {
+          symbolLookup: "NBK.KW",
+          date: new Date("2026-02-15T00:00:00.000Z"),
+        },
+      ],
+      { staleGuardDays: 0 },
+    );
+
+    expect(result.get("nbk-symbol|2026-02-15")).toBeCloseTo(0.838, 10);
+    expect(state.upsertCalls).toHaveLength(1);
+
+    const row = state.upsertCalls[0]?.rows[0];
+    expect(row).toMatchObject({
+      symbol_id: "nbk-symbol",
+      date: "2026-02-14",
+    });
+    expect(row?.close_price).toBeCloseTo(0.838, 10);
+    expect(row?.adjusted_close_price).toBeCloseTo(0.837, 10);
+  });
+
+  it("normalizes regularMarketPrice fallback before caching and returning", async () => {
+    vi.setSystemTime(new Date("2026-02-15T23:00:00.000Z"));
+
+    const { client, state } = createSupabaseStub([]);
+    createServiceClientMock.mockResolvedValue(client);
+    mockSymbolResolution({
+      lookup: "BP.L",
+      canonicalId: "bp-symbol",
+      providerAlias: "BP.L",
+      quoteToCurrencyRate: 0.01,
+    });
+    yahooChartMock.mockResolvedValue({
+      quotes: [],
+      meta: {
+        regularMarketPrice: 524.4,
+        regularMarketTime: new Date("2026-02-14T00:00:00.000Z"),
+      },
+    });
+
+    const { fetchQuotes } = await import("./fetch");
+
+    const result = await fetchQuotes(
+      [
+        {
+          symbolLookup: "BP.L",
+          date: new Date("2026-02-15T00:00:00.000Z"),
+        },
+      ],
+      { staleGuardDays: 0 },
+    );
+
+    expect(result.get("bp-symbol|2026-02-15")).toBeCloseTo(5.244, 10);
+    expect(state.upsertCalls).toHaveLength(1);
+    expect(state.upsertCalls[0]?.rows).toHaveLength(1);
+
+    const row = state.upsertCalls[0]?.rows[0];
+    expect(row).toMatchObject({
+      symbol_id: "bp-symbol",
+      date: "2026-02-14",
+    });
+    expect(row?.close_price).toBeCloseTo(5.244, 10);
+    expect(row?.adjusted_close_price).toBeCloseTo(5.244, 10);
   });
 
   it("uses previous trading day before cutoff for today requests", async () => {
@@ -607,14 +746,14 @@ describe("fetchQuotes", () => {
 
     resolveSymbolsBatchMock.mockResolvedValue({
       byInput: new Map([
-        ["sym-1", { canonicalId: "sym-1" }],
-        ["sym-2", { canonicalId: "sym-2" }],
-        ["sym-3", { canonicalId: "sym-3" }],
+        ["sym-1", { canonicalId: "sym-1", quoteToCurrencyRate: 1 }],
+        ["sym-2", { canonicalId: "sym-2", quoteToCurrencyRate: 1 }],
+        ["sym-3", { canonicalId: "sym-3", quoteToCurrencyRate: 1 }],
       ]),
       byCanonicalId: new Map([
-        ["sym-1", { providerAlias: "AAPL" }],
-        ["sym-2", { providerAlias: "MSFT" }],
-        ["sym-3", { providerAlias: "GOOG" }],
+        ["sym-1", { providerAlias: "AAPL", quoteToCurrencyRate: 1 }],
+        ["sym-2", { providerAlias: "MSFT", quoteToCurrencyRate: 1 }],
+        ["sym-3", { providerAlias: "GOOG", quoteToCurrencyRate: 1 }],
       ]),
     });
 

--- a/server/quotes/fetch.ts
+++ b/server/quotes/fetch.ts
@@ -3,6 +3,7 @@
 import { addDays, subDays } from "date-fns";
 
 import { formatUTCDateKey, parseUTCDateKey } from "@/lib/date/date-utils";
+import { normalizeQuoteToCurrencyRate } from "@/server/market-data/quote-units";
 import { chunkArray } from "@/server/shared/chunk-array";
 import { yahooFinance } from "@/server/yahoo-finance/client";
 import { createServiceClient } from "@/supabase/service";
@@ -121,6 +122,21 @@ function findLatestEntryAtOrBefore(
     }
   }
   return null;
+}
+
+function scaleProviderQuoteEntries(
+  entries: ReturnType<typeof normalizeChartQuoteEntries>,
+  quoteToCurrencyRate: number,
+): ReturnType<typeof normalizeChartQuoteEntries> {
+  if (quoteToCurrencyRate === 1) return entries;
+
+  // Yahoo chart prices are in the provider quote unit. Cache only normalized
+  // major-currency prices so valuations, P/L, and display code stay simple.
+  return entries.map((entry) => ({
+    ...entry,
+    closePrice: entry.closePrice * quoteToCurrencyRate,
+    adjustedClosePrice: entry.adjustedClosePrice * quoteToCurrencyRate,
+  }));
 }
 
 function buildLiveMissCooldownKey(request: {
@@ -415,6 +431,9 @@ export async function fetchQuotes(
 
       const resolution = byCanonicalId.get(symbolId);
       const ticker = resolution?.providerAlias;
+      const quoteToCurrencyRate = normalizeQuoteToCurrencyRate(
+        resolution?.quoteToCurrencyRate,
+      );
       if (!ticker) {
         console.warn(
           `Skipping quote fetch for symbol ${symbolId}: missing Yahoo ticker alias.`,
@@ -439,7 +458,10 @@ export async function fetchQuotes(
         chartData = null;
       }
 
-      const quoteEntries = normalizeChartQuoteEntries(chartData);
+      const quoteEntries = scaleProviderQuoteEntries(
+        normalizeChartQuoteEntries(chartData),
+        quoteToCurrencyRate,
+      );
 
       if (resolvedOptions.upsert) {
         quoteEntries.forEach((entry) => {
@@ -472,13 +494,17 @@ export async function fetchQuotes(
       // Final safety net when chart rows do not resolve all requests.
       const fallbackPrice = chartData?.meta?.regularMarketPrice;
       const fallbackTime = chartData?.meta?.regularMarketTime;
+      const normalizedFallbackPrice =
+        typeof fallbackPrice === "number"
+          ? fallbackPrice * quoteToCurrencyRate
+          : fallbackPrice;
       const allSymbolRequestsResolved = symbolRequests.every((request) =>
         results.has(`${request.canonicalId}|${request.requestedDateKey}`),
       );
       if (
         !allSymbolRequestsResolved &&
-        fallbackPrice &&
-        fallbackPrice > 0 &&
+        normalizedFallbackPrice &&
+        normalizedFallbackPrice > 0 &&
         fallbackTime instanceof Date
       ) {
         const fallbackDateKey = formatUTCDateKey(fallbackTime);
@@ -488,8 +514,8 @@ export async function fetchQuotes(
           upsertRowsByKey.set(fallbackRowKey, {
             symbol_id: symbolId,
             date: fallbackDateKey,
-            close_price: fallbackPrice,
-            adjusted_close_price: fallbackPrice,
+            close_price: normalizedFallbackPrice,
+            adjusted_close_price: normalizedFallbackPrice,
           });
         }
 
@@ -498,7 +524,7 @@ export async function fetchQuotes(
           if (results.has(mapKey)) return;
 
           if (fallbackDateKey <= request.effectiveDateKey) {
-            results.set(mapKey, fallbackPrice);
+            results.set(mapKey, normalizedFallbackPrice);
             resolutionTypeByRequestKey.set(
               mapKey,
               fallbackDateKey === request.effectiveDateKey

--- a/server/symbols/create.test.ts
+++ b/server/symbols/create.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getCurrentUserMock,
+  fetchYahooFinanceSymbolMock,
+  fetchCurrenciesMock,
+  setPrimarySymbolAliasMock,
+  createServiceClientMock,
+} = vi.hoisted(() => ({
+  getCurrentUserMock: vi.fn(),
+  fetchYahooFinanceSymbolMock: vi.fn(),
+  fetchCurrenciesMock: vi.fn(),
+  setPrimarySymbolAliasMock: vi.fn(),
+  createServiceClientMock: vi.fn(),
+}));
+
+vi.mock("@/server/auth/actions", () => ({
+  getCurrentUser: getCurrentUserMock,
+}));
+
+vi.mock("@/server/symbols/search", () => ({
+  fetchYahooFinanceSymbol: fetchYahooFinanceSymbolMock,
+}));
+
+vi.mock("@/server/currencies/fetch", () => ({
+  fetchCurrencies: fetchCurrenciesMock,
+}));
+
+vi.mock("@/server/symbols/resolve", () => ({
+  setPrimarySymbolAlias: setPrimarySymbolAliasMock,
+}));
+
+vi.mock("@/supabase/service", () => ({
+  createServiceClient: createServiceClientMock,
+}));
+
+function createSupabaseStub() {
+  const state = {
+    upsertRows: [] as Array<Record<string, unknown>>,
+  };
+
+  const symbolsApi = {
+    upsert(row: Record<string, unknown>) {
+      state.upsertRows.push({ ...row });
+
+      return {
+        select() {
+          return {
+            async single() {
+              return {
+                data: {
+                  id: "symbol-1",
+                  ...row,
+                },
+                error: null,
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return {
+    state,
+    client: {
+      from(table: string) {
+        if (table !== "symbols") {
+          throw new Error(`Unexpected table "${table}"`);
+        }
+
+        return symbolsApi;
+      },
+    },
+  };
+}
+
+describe("createSymbol", () => {
+  beforeEach(() => {
+    getCurrentUserMock.mockReset();
+    fetchYahooFinanceSymbolMock.mockReset();
+    fetchCurrenciesMock.mockReset();
+    setPrimarySymbolAliasMock.mockReset();
+    createServiceClientMock.mockReset();
+
+    getCurrentUserMock.mockResolvedValue({ user: { id: "user-1" } });
+    fetchCurrenciesMock.mockResolvedValue([
+      { alphabetic_code: "GBP", name: "Pound Sterling" },
+      { alphabetic_code: "KWD", name: "Kuwaiti Dinar" },
+    ]);
+    setPrimarySymbolAliasMock.mockResolvedValue({});
+  });
+
+  it("accepts a symbol whose Yahoo quote unit normalizes to supported GBP", async () => {
+    const { client, state } = createSupabaseStub();
+    createServiceClientMock.mockReturnValue(client);
+    fetchYahooFinanceSymbolMock.mockResolvedValue({
+      success: true,
+      data: {
+        ticker: "BP.L",
+        quote_type: "EQUITY",
+        short_name: "BP p.l.c.",
+        long_name: "BP p.l.c.",
+        currency: "GBP",
+        quote_currency: "GBp",
+        quote_to_currency_rate: 0.01,
+        exchange: "LSE",
+        sector: "Energy",
+        industry: "Oil & Gas Integrated",
+      },
+    });
+
+    const { createSymbol } = await import("./create");
+    const result = await createSymbol("BP.L");
+
+    expect(result.success).toBe(true);
+    expect(state.upsertRows).toEqual([
+      {
+        ticker: "BP.L",
+        quote_type: "EQUITY",
+        short_name: "BP p.l.c.",
+        long_name: "BP p.l.c.",
+        currency: "GBP",
+        quote_currency: "GBp",
+        quote_to_currency_rate: 0.01,
+        exchange: "LSE",
+        sector: "Energy",
+        industry: "Oil & Gas Integrated",
+      },
+    ]);
+  });
+
+  it("accepts a symbol whose Yahoo quote unit normalizes to supported KWD", async () => {
+    const { client, state } = createSupabaseStub();
+    createServiceClientMock.mockReturnValue(client);
+    fetchYahooFinanceSymbolMock.mockResolvedValue({
+      success: true,
+      data: {
+        ticker: "NBK.KW",
+        quote_type: "EQUITY",
+        short_name: "NBK",
+        long_name: "National Bank of Kuwait",
+        currency: "KWD",
+        quote_currency: "KWF",
+        quote_to_currency_rate: 0.001,
+        exchange: "Kuwait",
+        sector: null,
+        industry: null,
+      },
+    });
+
+    const { createSymbol } = await import("./create");
+    const result = await createSymbol("NBK.KW");
+
+    expect(result.success).toBe(true);
+    expect(state.upsertRows[0]).toMatchObject({
+      ticker: "NBK.KW",
+      currency: "KWD",
+      quote_currency: "KWF",
+      quote_to_currency_rate: 0.001,
+    });
+  });
+});

--- a/server/symbols/create.ts
+++ b/server/symbols/create.ts
@@ -45,7 +45,9 @@ export async function createSymbol(symbolTicker: string) {
     };
   }
 
-  // 3) Insert/update symbol metadata and fetch canonical row
+  // 3) Insert/update symbol metadata and fetch canonical row. The Yahoo fetcher
+  // already returns a DB insert payload with normalized ISO currency plus the
+  // original provider quote unit and multiplier.
   const { data: upsertedSymbol, error: upsertError } = await supabase
     .from("symbols")
     .upsert(symbolData, { onConflict: "ticker" })

--- a/server/symbols/resolve.test.ts
+++ b/server/symbols/resolve.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 type SymbolRow = {
   id: string;
   ticker: string;
+  currency?: string;
+  quote_to_currency_rate?: number;
 };
 
 type SymbolAliasRow = {
@@ -135,7 +137,13 @@ function createSupabaseStub(data: {
             });
           });
 
-          return Promise.resolve({ data: rows, error: null }).then(
+          const rowsWithDefaults = rows.map((row) => ({
+            currency: "USD",
+            quote_to_currency_rate: 1,
+            ...row,
+          }));
+
+          return Promise.resolve({ data: rowsWithDefaults, error: null }).then(
             onfulfilled ?? undefined,
             onrejected,
           );
@@ -320,15 +328,21 @@ describe("resolveSymbolsBatch", () => {
       canonicalId: symbolIdOne,
       providerAlias: "AAPL",
       displayTicker: "AAPL",
+      currency: "USD",
+      quoteToCurrencyRate: 1,
     });
     expect(result.byInput.get("msft")).toEqual({
       canonicalId: symbolIdTwo,
       providerAlias: "MSFT",
       displayTicker: "MSFT",
+      currency: "USD",
+      quoteToCurrencyRate: 1,
     });
     expect(result.byCanonicalId.get(symbolIdTwo)).toEqual({
       providerAlias: "MSFT",
       displayTicker: "MSFT",
+      currency: "USD",
+      quoteToCurrencyRate: 1,
     });
 
     expect(state.symbolQueryCount).toBe(1);
@@ -370,11 +384,59 @@ describe("resolveSymbolsBatch", () => {
       canonicalId: symbolIdPrimaryFallback,
       providerAlias: "ALIAS_PRI",
       displayTicker: "ALIAS_PRI",
+      currency: "USD",
+      quoteToCurrencyRate: 1,
     });
     expect(result.byInput.get(symbolIdTickerFallback)).toEqual({
       canonicalId: symbolIdTickerFallback,
       providerAlias: "TICKER_ONLY",
       displayTicker: "TICKER_ONLY",
+      currency: "USD",
+      quoteToCurrencyRate: 1,
+    });
+  });
+
+  it("includes normalized currency and quote-to-currency rate from symbol metadata", async () => {
+    const symbolId = "99999999-9999-9999-9999-999999999999";
+    const { client } = createSupabaseStub({
+      symbols: [
+        {
+          id: symbolId,
+          ticker: "BP.L",
+          currency: "GBP",
+          quote_to_currency_rate: 0.01,
+        },
+      ],
+      symbolAliases: [
+        {
+          symbol_id: symbolId,
+          value: "BP.L",
+          type: "ticker",
+          source: "yahoo",
+          is_primary: true,
+          effective_from: "2026-01-01T00:00:00.000Z",
+          effective_to: null,
+        },
+      ],
+    });
+
+    createServiceClientMock.mockResolvedValue(client);
+    const { resolveSymbolsBatch } = await import("./resolve");
+
+    const result = await resolveSymbolsBatch(["bp.l"]);
+
+    expect(result.byInput.get("bp.l")).toEqual({
+      canonicalId: symbolId,
+      providerAlias: "BP.L",
+      displayTicker: "BP.L",
+      currency: "GBP",
+      quoteToCurrencyRate: 0.01,
+    });
+    expect(result.byCanonicalId.get(symbolId)).toEqual({
+      providerAlias: "BP.L",
+      displayTicker: "BP.L",
+      currency: "GBP",
+      quoteToCurrencyRate: 0.01,
     });
   });
 
@@ -404,6 +466,8 @@ describe("resolveSymbolsBatch", () => {
       canonicalId: symbolId,
       providerAlias: "MsFt",
       displayTicker: "MsFt",
+      currency: "USD",
+      quoteToCurrencyRate: 1,
     });
     expect(state.symbolQueryCount).toBe(1);
     expect(state.symbolAliasesQueryCount).toBe(4);
@@ -440,6 +504,8 @@ describe("resolveSymbolsBatch", () => {
       canonicalId: symbolId,
       providerAlias: "VALID",
       displayTicker: "VALID",
+      currency: "USD",
+      quoteToCurrencyRate: 1,
     });
     expect(result.byInput.has("missing")).toBe(false);
     expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -494,6 +560,8 @@ describe("resolveSymbolsBatch", () => {
       canonicalId: symbolId,
       providerAlias: "VALID",
       displayTicker: "VALID",
+      currency: "USD",
+      quoteToCurrencyRate: 1,
     });
     expect(result.byInput.has("missing")).toBe(false);
     expect(consoleWarnSpy).not.toHaveBeenCalled();

--- a/server/symbols/resolve.ts
+++ b/server/symbols/resolve.ts
@@ -2,6 +2,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+import { normalizeQuoteToCurrencyRate } from "@/server/market-data/quote-units";
 import { chunkArray } from "@/server/shared/chunk-array";
 import { normalizeSymbol } from "@/server/symbols/validate";
 import { createServiceClient } from "@/supabase/service";
@@ -611,16 +612,12 @@ async function fetchSymbolMetadataById(
     }
 
     data?.forEach((symbolRow) => {
-      const quoteToCurrencyRate =
-        Number.isFinite(symbolRow.quote_to_currency_rate) &&
-        symbolRow.quote_to_currency_rate > 0
-          ? symbolRow.quote_to_currency_rate
-          : 1;
-
       metadataBySymbolId.set(symbolRow.id, {
         ticker: symbolRow.ticker,
         currency: symbolRow.currency,
-        quoteToCurrencyRate,
+        quoteToCurrencyRate: normalizeQuoteToCurrencyRate(
+          symbolRow.quote_to_currency_rate,
+        ),
       });
     });
   }

--- a/server/symbols/resolve.ts
+++ b/server/symbols/resolve.ts
@@ -34,6 +34,27 @@ export interface ProviderAliasOptions {
   includeInactive?: boolean;
 }
 
+interface ResolvedSymbolInputMetadata {
+  canonicalId: string;
+  providerAlias: string;
+  displayTicker: string | null;
+  currency: string;
+  quoteToCurrencyRate: number;
+}
+
+interface ResolvedSymbolCanonicalMetadata {
+  providerAlias: string;
+  displayTicker: string | null;
+  currency: string;
+  quoteToCurrencyRate: number;
+}
+
+interface SymbolResolutionMetadata {
+  ticker: string;
+  currency: string;
+  quoteToCurrencyRate: number;
+}
+
 /**
  * Resolve a user or provider supplied identifier to the canonical symbol UUID.
  * Accepts UUIDs directly; otherwise looks up an alias of the requested type/source.
@@ -319,41 +340,15 @@ export async function resolveSymbolsBatch(
     onError?: "throw" | "warn" | "skip";
   } = {},
 ): Promise<{
-  byInput: Map<
-    string,
-    {
-      canonicalId: string;
-      providerAlias: string;
-      displayTicker: string | null;
-    }
-  >;
-  byCanonicalId: Map<
-    string,
-    {
-      providerAlias: string;
-      displayTicker: string | null;
-    }
-  >;
+  byInput: Map<string, ResolvedSymbolInputMetadata>;
+  byCanonicalId: Map<string, ResolvedSymbolCanonicalMetadata>;
 }> {
   const provider = options.provider ?? DEFAULT_ALIAS_SOURCE;
   const providerType = options.providerType ?? DEFAULT_ALIAS_TYPE;
   const onError = options.onError ?? "throw";
 
-  const byInput = new Map<
-    string,
-    {
-      canonicalId: string;
-      providerAlias: string;
-      displayTicker: string | null;
-    }
-  >();
-  const byCanonicalId = new Map<
-    string,
-    {
-      providerAlias: string;
-      displayTicker: string | null;
-    }
-  >();
+  const byInput = new Map<string, ResolvedSymbolInputMetadata>();
+  const byCanonicalId = new Map<string, ResolvedSymbolCanonicalMetadata>();
 
   // Deduplicate and normalize inputs once.
   const uniqueInputs = [
@@ -383,7 +378,7 @@ export async function resolveSymbolsBatch(
   );
 
   let canonicalByInput = new Map<string, string>();
-  let tickerBySymbolId = new Map<string, string>();
+  let metadataBySymbolId = new Map<string, SymbolResolutionMetadata>();
   let primaryAliasBySymbolId = new Map<string, string>();
   let providerAliasBySymbolId = new Map<string, string>();
 
@@ -432,7 +427,7 @@ export async function resolveSymbolsBatch(
     });
 
     const canonicalIds = [...new Set(canonicalByInput.values())];
-    tickerBySymbolId = await fetchSymbolTickersById(supabase, canonicalIds);
+    metadataBySymbolId = await fetchSymbolMetadataById(supabase, canonicalIds);
     primaryAliasBySymbolId = await fetchPrimaryAliasesBySymbolId(
       supabase,
       canonicalIds,
@@ -464,7 +459,10 @@ export async function resolveSymbolsBatch(
     try {
       // 1) Resolve input to canonical symbol ID.
       const canonicalId = canonicalByInput.get(inputKey);
-      if (!canonicalId || !tickerBySymbolId.has(canonicalId)) {
+      const symbolMetadata = canonicalId
+        ? metadataBySymbolId.get(canonicalId)
+        : undefined;
+      if (!canonicalId || !symbolMetadata) {
         const errorMsg = `Unable to resolve symbol identifier "${inputKey}" to a canonical symbol.`;
         if (onError === "throw") {
           throw new Error(errorMsg);
@@ -479,7 +477,7 @@ export async function resolveSymbolsBatch(
       const providerAlias =
         providerAliasBySymbolId.get(canonicalId) ??
         primaryAliasBySymbolId.get(canonicalId) ??
-        tickerBySymbolId.get(canonicalId);
+        symbolMetadata.ticker;
 
       if (!providerAlias) {
         const errorMsg = `Symbol "${inputKey}" is missing a ${provider} ${providerType} alias.`;
@@ -495,19 +493,23 @@ export async function resolveSymbolsBatch(
       // 3) Resolve display ticker and store maps.
       const displayTicker =
         primaryAliasBySymbolId.get(canonicalId) ??
-        tickerBySymbolId.get(canonicalId) ??
+        symbolMetadata.ticker ??
         null;
 
       byInput.set(inputKey, {
         canonicalId,
         providerAlias,
         displayTicker,
+        currency: symbolMetadata.currency,
+        quoteToCurrencyRate: symbolMetadata.quoteToCurrencyRate,
       });
 
       if (!byCanonicalId.has(canonicalId)) {
         byCanonicalId.set(canonicalId, {
           providerAlias,
           displayTicker,
+          currency: symbolMetadata.currency,
+          quoteToCurrencyRate: symbolMetadata.quoteToCurrencyRate,
         });
       }
     } catch (error) {
@@ -591,17 +593,17 @@ async function fetchCanonicalIdsByAliasLookupsCaseInsensitive(
   return canonicalByAliasLookup;
 }
 
-async function fetchSymbolTickersById(
+async function fetchSymbolMetadataById(
   supabase: SupabaseClient<Database>,
   symbolIds: string[],
 ) {
-  const tickerBySymbolId = new Map<string, string>();
-  if (!symbolIds.length) return tickerBySymbolId;
+  const metadataBySymbolId = new Map<string, SymbolResolutionMetadata>();
+  if (!symbolIds.length) return metadataBySymbolId;
 
   for (const symbolIdChunk of chunkArray(symbolIds, BATCH_QUERY_CHUNK_SIZE)) {
     const { data, error } = await supabase
       .from("symbols")
-      .select("id, ticker")
+      .select("id, ticker, currency, quote_to_currency_rate")
       .in("id", symbolIdChunk);
 
     if (error) {
@@ -609,11 +611,21 @@ async function fetchSymbolTickersById(
     }
 
     data?.forEach((symbolRow) => {
-      tickerBySymbolId.set(symbolRow.id, symbolRow.ticker);
+      const quoteToCurrencyRate =
+        Number.isFinite(symbolRow.quote_to_currency_rate) &&
+        symbolRow.quote_to_currency_rate > 0
+          ? symbolRow.quote_to_currency_rate
+          : 1;
+
+      metadataBySymbolId.set(symbolRow.id, {
+        ticker: symbolRow.ticker,
+        currency: symbolRow.currency,
+        quoteToCurrencyRate,
+      });
     });
   }
 
-  return tickerBySymbolId;
+  return metadataBySymbolId;
 }
 
 async function fetchPrimaryAliasesBySymbolId(

--- a/server/symbols/search.test.ts
+++ b/server/symbols/search.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { quoteSummaryMock } = vi.hoisted(() => ({
+  quoteSummaryMock: vi.fn(),
+}));
+
+vi.mock("@/server/yahoo-finance/client", () => ({
+  yahooFinance: {
+    quoteSummary: quoteSummaryMock,
+  },
+}));
+
+describe("fetchYahooFinanceSymbol", () => {
+  beforeEach(() => {
+    quoteSummaryMock.mockReset();
+  });
+
+  it("normalizes UK pence quote units into GBP symbol currency", async () => {
+    quoteSummaryMock.mockResolvedValue({
+      price: {
+        quoteType: "EQUITY",
+        shortName: "BP p.l.c.",
+        longName: "BP p.l.c.",
+        currency: "GBp",
+        exchangeName: "LSE",
+      },
+      assetProfile: {
+        sector: "Energy",
+        industry: "Oil & Gas Integrated",
+      },
+    });
+
+    const { fetchYahooFinanceSymbol } = await import("./search");
+    const result = await fetchYahooFinanceSymbol("bp.l");
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        ticker: "BP.L",
+        quote_type: "EQUITY",
+        short_name: "BP p.l.c.",
+        long_name: "BP p.l.c.",
+        currency: "GBP",
+        quote_currency: "GBp",
+        quote_to_currency_rate: 0.01,
+        exchange: "LSE",
+        sector: "Energy",
+        industry: "Oil & Gas Integrated",
+      },
+    });
+  });
+
+  it("normalizes Kuwaiti fils quote units into KWD symbol currency", async () => {
+    quoteSummaryMock.mockResolvedValue({
+      price: {
+        quoteType: "EQUITY",
+        shortName: "NBK",
+        longName: "National Bank of Kuwait",
+        currency: "KWF",
+        exchangeName: "Kuwait",
+      },
+      assetProfile: {},
+    });
+
+    const { fetchYahooFinanceSymbol } = await import("./search");
+    const result = await fetchYahooFinanceSymbol("nbk.kw");
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        ticker: "NBK.KW",
+        quote_type: "EQUITY",
+        short_name: "NBK",
+        long_name: "National Bank of Kuwait",
+        currency: "KWD",
+        quote_currency: "KWF",
+        quote_to_currency_rate: 0.001,
+        exchange: "Kuwait",
+        sector: null,
+        industry: null,
+      },
+    });
+  });
+});

--- a/server/symbols/search.ts
+++ b/server/symbols/search.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 
+import { normalizeProviderQuoteUnit } from "@/server/market-data/quote-units";
 import { yahooFinance } from "@/server/yahoo-finance/client";
 
 import type { SymbolInsert, SymbolSearchResult } from "@/types/global.types";
@@ -68,13 +69,26 @@ export async function fetchYahooFinanceSymbol(symbolId: string) {
     const price = summary.price;
     const profile = summary.assetProfile;
 
+    const normalizedQuoteUnit = normalizeProviderQuoteUnit(price?.currency);
+    if (!normalizedQuoteUnit.success) {
+      return {
+        success: false,
+        code: normalizedQuoteUnit.code,
+        message: normalizedQuoteUnit.message,
+      };
+    }
+
     const normalizedTicker = symbolId.trim().toUpperCase();
+    // Yahoo price.currency can be a quote unit such as GBp/KWF rather than an
+    // ISO accounting currency. Normalize it before the symbol ever reaches DB.
     const data: SymbolInsert = {
       ticker: normalizedTicker,
       quote_type: price?.quoteType || "",
       short_name: price?.shortName || symbolId,
       long_name: price?.longName || price?.shortName || symbolId,
-      currency: price?.currency || "",
+      currency: normalizedQuoteUnit.data.currency,
+      quote_currency: normalizedQuoteUnit.data.quoteCurrency,
+      quote_to_currency_rate: normalizedQuoteUnit.data.quoteToCurrencyRate,
       exchange: price?.exchangeName || price?.exchange || null,
       sector: profile?.sector || null,
       industry: profile?.industry || null,

--- a/server/symbols/validate.test.ts
+++ b/server/symbols/validate.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchYahooFinanceSymbolMock, searchYahooFinanceSymbolsMock } =
+  vi.hoisted(() => ({
+    fetchYahooFinanceSymbolMock: vi.fn(),
+    searchYahooFinanceSymbolsMock: vi.fn(),
+  }));
+
+vi.mock("./search", () => ({
+  fetchYahooFinanceSymbol: fetchYahooFinanceSymbolMock,
+  searchYahooFinanceSymbols: searchYahooFinanceSymbolsMock,
+}));
+
+describe("validateSymbol", () => {
+  beforeEach(() => {
+    fetchYahooFinanceSymbolMock.mockReset();
+    searchYahooFinanceSymbolsMock.mockReset();
+  });
+
+  it("returns normalized ISO currency for UK pence-quoted symbols", async () => {
+    fetchYahooFinanceSymbolMock.mockResolvedValue({
+      success: true,
+      data: {
+        currency: "GBP",
+      },
+    });
+
+    const { validateSymbol } = await import("./validate");
+    const result = await validateSymbol("bp.l");
+
+    expect(result).toEqual({
+      valid: true,
+      normalized: "BP.L",
+      currency: "GBP",
+    });
+  });
+
+  it("returns normalized ISO currency for Kuwaiti fils-quoted symbols", async () => {
+    fetchYahooFinanceSymbolMock.mockResolvedValue({
+      success: true,
+      data: {
+        currency: "KWD",
+      },
+    });
+
+    const { validateSymbol } = await import("./validate");
+    const result = await validateSymbol("nbk.kw");
+
+    expect(result).toEqual({
+      valid: true,
+      normalized: "NBK.KW",
+      currency: "KWD",
+    });
+  });
+});

--- a/supabase/migrations/20260603074032_add_quote_unit_metadata.sql
+++ b/supabase/migrations/20260603074032_add_quote_unit_metadata.sql
@@ -1,0 +1,60 @@
+BEGIN;
+
+ALTER TABLE public.symbols
+  ADD COLUMN quote_currency text DEFAULT '';
+
+ALTER TABLE public.symbols
+  ADD COLUMN quote_to_currency_rate numeric(20, 10) DEFAULT 1;
+
+UPDATE public.symbols
+SET
+  quote_currency = currency,
+  quote_to_currency_rate = 1
+WHERE quote_currency IS NULL
+  OR btrim(quote_currency) = ''
+  OR quote_to_currency_rate IS NULL;
+
+CREATE OR REPLACE FUNCTION public.set_symbol_quote_unit_defaults()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.quote_currency IS NULL OR btrim(NEW.quote_currency) = '' THEN
+    NEW.quote_currency := NEW.currency;
+  END IF;
+
+  IF NEW.quote_to_currency_rate IS NULL THEN
+    NEW.quote_to_currency_rate := 1;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER symbols_set_quote_unit_defaults
+  BEFORE INSERT OR UPDATE OF currency, quote_currency, quote_to_currency_rate
+  ON public.symbols
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_symbol_quote_unit_defaults();
+
+ALTER TABLE public.symbols
+  ALTER COLUMN quote_currency SET NOT NULL,
+  ALTER COLUMN quote_to_currency_rate SET NOT NULL,
+  ALTER COLUMN quote_to_currency_rate SET DEFAULT 1;
+
+ALTER TABLE public.symbols
+  ADD CONSTRAINT symbols_quote_currency_not_empty_check
+  CHECK (btrim(quote_currency) <> '');
+
+ALTER TABLE public.symbols
+  ADD CONSTRAINT symbols_quote_to_currency_rate_positive_check
+  CHECK (quote_to_currency_rate > 0);
+
+COMMENT ON COLUMN public.symbols.quote_currency IS
+  'Provider quote unit for symbol prices (may be non-ISO, e.g. GBp, GBX, KWF).';
+
+COMMENT ON COLUMN public.symbols.quote_to_currency_rate IS
+  'Multiplier to convert provider quote-unit prices into symbols.currency major units.';
+
+COMMIT;

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -946,6 +946,8 @@ export type Database = {
           industry: string | null
           last_quote_at: string | null
           long_name: string | null
+          quote_currency: string
+          quote_to_currency_rate: number
           quote_type: string
           sector: string | null
           short_name: string | null
@@ -960,6 +962,8 @@ export type Database = {
           industry?: string | null
           last_quote_at?: string | null
           long_name?: string | null
+          quote_currency?: string
+          quote_to_currency_rate?: number
           quote_type: string
           sector?: string | null
           short_name?: string | null
@@ -974,6 +978,8 @@ export type Database = {
           industry?: string | null
           last_quote_at?: string | null
           long_name?: string | null
+          quote_currency?: string
+          quote_to_currency_rate?: number
           quote_type?: string
           sector?: string | null
           short_name?: string | null


### PR DESCRIPTION
## Summary

Adds UK and Kuwait market support while keeping `public.currencies` ISO-only. Provider quote units such as `GBp`/`GBX` (pence) and `KWF` (Kuwaiti fils) are decoded at symbol ingestion and scaled into major ISO currencies (`GBP`, `KWD`) before values enter symbols, quote cache, dividend events, position import, and downstream valuation.

- Introduces `server/market-data/quote-units.ts` with a small provider-unit registry (`GBp`/`GBX` → `GBP` ×0.01, `KWF` → `KWD` ×0.001, ISO passthrough ×1) and clear errors for unsupported units.
- Adds `symbols.quote_currency` and `symbols.quote_to_currency_rate` (migration `20260603074032_add_quote_unit_metadata.sql`), backfills existing rows to multiplier `1`, and persists per-symbol quote metadata during symbol create/search/resolve.
- Normalizes Yahoo quote cache prices and chart dividend event amounts using `quote_to_currency_rate`; summary dividend fields are intentionally not scaled because Yahoo may already report them in major currency.
- Updates position CSV/AI import to accept broker quote units on symbol-backed rows, scale `unit_value` / `cost_basis_per_unit`, and set normalized ISO accounting currency; import UI tooltips and docs updated accordingly.

## Key behavior

| Source | Raw example | Stored / imported |
|--------|-------------|-------------------|
| Quote cache | `524.4 GBp` | `5.244 GBP` |
| Quote cache | `838 KWF` | `0.838 KWD` |
| Chart dividend | `6.1780996 GBp` | `0.061780996 GBP` |
| CSV import (symbol row) | `currency=GBp`, `unit_value=524.4` | `currency=GBP`, `unit_value=5.244` |

Downstream valuation (`fetchPositions({ asOfDateKey })`) should remain unchanged because cached quotes are already normalized major-currency prices.

## Migration / deploy notes

- Apply migration `20260603074032_add_quote_unit_metadata.sql` before deploying app code.
- Regenerate or verify `types/database.types.ts` matches the migration (types were updated manually in this branch).
- Ensure `KWD` exists in `public.currencies` via admin/deploy workflow (not inserted by migration).

## Docs

- `docs/quote-unit-normalization-plan.md` — phased implementation plan
- Updated: `docs/QUOTE-FETCH-BEHAVIOR.md`, `docs/MARKET-DATA-HUB.md`, `docs/QUOTE-CACHE-RESEED.md`