### PR TITLE
Add Directa and Scalable Capital broker adapters

### DIFF
--- a/.claude/skills/ponytail-audit/SKILL.md
+++ b/.claude/skills/ponytail-audit/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: ponytail-audit
+description: >
+  Whole-repo audit for over-engineering. Like ponytail-review, but scans the
+  entire codebase instead of a diff: a ranked list of what to delete, simplify,
+  or replace with stdlib/native equivalents. Use when the user says "audit this
+  codebase", "audit for over-engineering", "what can I delete from this repo",
+  "find bloat", "ponytail-audit", or "/ponytail-audit". One-shot report, does
+  not apply fixes.
+---
+
+ponytail-review, repo-wide. Scan the whole tree instead of a diff. Rank
+findings biggest cut first.
+
+## Tags
+
+Same as ponytail-review:
+
+- `delete:` dead code, unused flexibility, speculative feature. Replacement: nothing.
+- `stdlib:` hand-rolled thing the standard library ships. Name the function.
+- `native:` dependency or code doing what the platform already does. Name the feature.
+- `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `shrink:` same logic, fewer lines. Show the shorter form.
+
+## Hunt
+
+Deps the stdlib or platform already ships, single-implementation interfaces,
+factories with one product, wrappers that only delegate, files exporting one
+thing, dead flags and config, hand-rolled stdlib.
+
+## Output
+
+One line per finding, ranked: `<tag> <what to cut>. <replacement>. [path]`.
+End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. Ship.`
+
+## Boundaries
+
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope. Route them to a normal review
+pass. Lists findings, applies nothing. One-shot.
+"stop ponytail-audit" or "normal mode" to revert.

--- a/.claude/skills/ponytail-debt/SKILL.md
+++ b/.claude/skills/ponytail-debt/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ponytail-debt
+description: >
+  Harvest every `ponytail:` comment in the codebase into a debt ledger, so the
+  deliberate shortcuts and deferrals ponytail leaves behind get tracked instead
+  of rotting into "later means never". Use when the user says "ponytail debt",
+  "/ponytail-debt", "what did ponytail defer", "list the shortcuts", "ponytail
+  ledger", or "what did we mark to do later". One-shot report, changes nothing.
+---
+
+Every deliberate ponytail shortcut is marked with a `ponytail:` comment naming
+its ceiling and upgrade path. This collects them into one ledger so a deferral
+can't quietly become permanent.
+
+## Scan
+
+Grep the repo for comment markers, skipping `node_modules`, `.git`, and build
+output:
+
+`grep -rnE '(#|//) ?ponytail:' .`  (add other comment prefixes if your stack uses them)
+
+Each hit is one ledger row. The comment prefix keeps prose that merely mentions
+the convention out of the ledger.
+
+## Output
+
+One row per marker, grouped by file:
+
+`<file>:<line>, <what was simplified>. ceiling: <the limit named>. upgrade: <the trigger to revisit>.`
+
+The convention is `ponytail: <ceiling>, <upgrade path>`, so pull the ceiling
+and the trigger straight from the comment. Want an owner per row too? add
+`git blame -L<line>,<line>`.
+
+Flag the rot risk: any `ponytail:` comment that names no upgrade path or
+trigger gets a `no-trigger` tag, those are the ones that silently rot.
+
+End with `<N> markers, <M> with no trigger.` Nothing found: `No ponytail: debt. Clean ledger.`
+
+## Boundaries
+
+Reads and reports only, changes nothing. To persist it, ask and it writes the
+ledger to a file (e.g. `PONYTAIL-DEBT.md`). One-shot. "stop ponytail-debt" or
+"normal mode" to revert.

--- a/.claude/skills/ponytail-gain/SKILL.md
+++ b/.claude/skills/ponytail-gain/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ponytail-gain
+description: >
+  Show ponytail's measured impact as a compact scoreboard: less code, less
+  cost, more speed, from the benchmark medians. One-shot display, not a
+  persistent mode, and not a per-repo number. Trigger: /ponytail-gain,
+  "ponytail gain", "what does ponytail save", "show ponytail impact",
+  "ponytail scoreboard".
+---
+
+# Ponytail Gain
+
+Display this scoreboard when invoked. One-shot: do NOT change mode, write flag
+files, or persist anything.
+
+The figures are the published benchmark medians (5 everyday tasks: email
+validator, debounce, CSV sum, countdown timer, rate limiter; three models:
+Haiku, Sonnet, Opus). They are measured, not computed from the current repo.
+Source: `benchmarks/` and the README.
+
+## Scoreboard
+
+Render plain ASCII bars. The bar length shows the measured range; the label
+carries the exact figure:
+
+```
+  ponytail gain                     benchmark median · 5 tasks · 3 models
+
+  Lines of code   no-skill  ████████████████████  100%
+                  ponytail  ██▌·················    6–20%   ▼ 80–94%
+  Cost            no-skill  ████████████████████  100%
+                  ponytail  █████▌··············   23–53%  ▼ 47–77%
+  Speed           ponytail  ▸ 3–6× faster
+
+  This repo:  /ponytail-debt  (shortcuts you deferred)
+              /ponytail-audit (what's still cuttable)
+```
+
+## Honesty boundary
+
+These are benchmark medians, not this repo. NEVER print a per-repo savings
+number ("you saved X lines/tokens here"): the unbuilt version was never
+written, so there is no real baseline to subtract from in a live repo. The
+only real per-repo figures come from `/ponytail-debt` (a counted ledger), and
+this card points there instead of inventing one.
+
+## Boundaries
+
+One-shot display. Edits nothing, changes no mode.
+"stop ponytail" or "normal mode": revert.

--- a/.claude/skills/ponytail-help/SKILL.md
+++ b/.claude/skills/ponytail-help/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: ponytail-help
+description: >
+  Quick-reference card for all ponytail modes, skills, and commands.
+  One-shot display, not a persistent mode. Trigger: /ponytail-help,
+  "ponytail help", "what ponytail commands", "how do I use ponytail".
+---
+
+# Ponytail Help
+
+Display this reference card when invoked. One-shot, do NOT change mode,
+write flag files, or persist anything.
+
+## Levels
+
+| Level | Trigger | What change |
+|-------|---------|-------------|
+| **Lite** | `/ponytail lite` | Build what's asked, name the lazier alternative in one line. |
+| **Full** | `/ponytail` | The ladder enforced: YAGNI → stdlib → native → one line → minimum. Default. |
+| **Ultra** | `/ponytail ultra` | YAGNI extremist. Deletion before addition. Challenges requirements before building. |
+
+Level sticks until changed or session end.
+
+## Skills
+
+| Skill | Trigger | What it does |
+|-------|---------|--------------|
+| **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
+| **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
+| **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit: ranked list of what to delete. |
+| **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` shortcut comments into a tracked ledger. |
+| **ponytail-gain** | `/ponytail-gain` | Measured-impact scoreboard: less code, less cost, more speed. |
+| **ponytail-help** | `/ponytail-help` | This card. |
+
+Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
+and OpenCode use the slash-command forms above (OpenCode ships all six as
+slash commands).
+
+## Deactivate
+
+Say "stop ponytail" or "normal mode". Resume anytime with `/ponytail`.
+`/ponytail off` also works.
+
+## Configure Default Mode
+
+Default mode = `full`, auto-active every session. Change it:
+
+**Environment variable** (highest priority):
+```bash
+export PONYTAIL_DEFAULT_MODE=ultra
+```
+
+**Config file** (`~/.config/ponytail/config.json`, Windows: `%APPDATA%\ponytail\config.json`):
+```json
+{ "defaultMode": "lite" }
+```
+
+Set `"off"` to disable auto-activation on session start, activate manually
+with `/ponytail` when wanted.
+
+Resolution: env var > config file > `full`.
+
+## Update
+
+Enable auto-update once: open `/plugin`, go to Marketplaces, pick ponytail, Enable auto-update. Claude Code then pulls new versions at startup (run `/reload-plugins` when it prompts). Manual refresh: `/plugin marketplace update ponytail` then `/reload-plugins`.
+
+If `/plugin` is not recognized, your Claude Code is out of date. Update it (`npm install -g @anthropic-ai/claude-code@latest`, or `brew upgrade claude-code`) and restart. Other hosts use their own update flow.
+
+## More
+
+Full docs + examples: https://github.com/DietrichGebert/ponytail

--- a/.claude/skills/ponytail-review/SKILL.md
+++ b/.claude/skills/ponytail-review/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: ponytail-review
+description: >
+  Code review focused exclusively on over-engineering. Finds what to delete:
+  reinvented standard library, unneeded dependencies, speculative abstractions,
+  dead flexibility. One line per finding: location, what to cut, what replaces
+  it. Use when the user says "review for over-engineering", "what can we
+  delete", "is this over-engineered", "simplify review", or invokes
+  /ponytail-review. Complements correctness-focused review, this one only
+  hunts complexity.
+---
+
+Review diffs for unnecessary complexity. One line per finding: location, what
+to cut, what replaces it. The diff's best outcome is getting shorter.
+
+## Format
+
+`L<line>: <tag> <what>. <replacement>.`, or `<file>:L<line>: ...` for
+multi-file diffs.
+
+Tags:
+
+- `delete:` dead code, unused flexibility, speculative feature. Replacement: nothing.
+- `stdlib:` hand-rolled thing the standard library ships. Name the function.
+- `native:` dependency or code doing what the platform already does. Name the feature.
+- `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `shrink:` same logic, fewer lines. Show the shorter form.
+
+## Examples
+
+❌ "This EmailValidator class might be more complex than necessary, have you
+considered whether all these validation rules are needed at this stage?"
+
+✅ `L12-38: stdlib: 27-line validator class. "@" in email, 1 line, real validation is the confirmation mail.`
+
+✅ `L4: native: moment.js imported for one format call. Intl.DateTimeFormat, 0 deps.`
+
+✅ `repo.py:L88: yagni: AbstractRepository with one implementation. Inline it until a second one exists.`
+
+✅ `L52-71: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
+
+✅ `L30-44: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`
+
+## Scoring
+
+End with the only metric that matters: `net: -<N> lines possible.`
+
+If there is nothing to cut, say `Lean already. Ship.` and stop.
+
+## Boundaries
+
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope. Route them to a normal review
+pass, not this one. A single smoke test or `assert`-based
+self-check is the ponytail minimum, not bloat, never flag it for deletion.
+Does not apply the fixes, only lists them.
+"stop ponytail-review" or "normal mode": revert to verbose review style.

--- a/.claude/skills/ponytail/SKILL.md
+++ b/.claude/skills/ponytail/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  coding task: writing, adding, refactoring, fixing, reviewing, or designing
+  code, and choosing libraries or dependencies. Also use whenever the user
+  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
+  solution", "yagni", "do less", or "shortest path", or complains about
+  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
+  use for non-coding requests (general knowledge, prose, translation,
+  summaries, recipes).
+argument-hint: "[lite|full|ultra]"
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
+3. **Stdlib does it?** Use it.
+4. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+6. **Can it be one line?** One line.
+7. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project — but it runs *after* you
+understand the problem, not instead of it. Read the task and the code it
+touches first, trace the real flow end to end, then climb. Two rungs work →
+take the higher one and move on. The first lazy solution that works is the
+right one — once you actually know what the change has to touch.
+
+**Bug fix = root cause, not symptom.** A report names a symptom. Before you
+edit, grep every caller of the function you're about to touch. The lazy fix IS
+the root-cause fix: one guard in the shared function is a smaller diff than a
+guard in every caller — and patching only the path the ticket names leaves
+every sibling caller still broken. Fix it once, where all callers route through.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path (`# ponytail: global lock, per-account locks if throughput matters`).
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Never lazy about understanding the problem. The ladder shortens the
+solution, never the reading. Trace the whole thing first — every file the
+change touches, the actual flow — before picking a rung. Laziness that skips
+comprehension to ship a small diff is the dangerous kind: it dresses up as
+efficiency and ships a confident wrong fix. Read fully, then be lazy.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,9 @@ next-env.d.ts
 # cursor
 .cursor/mcp.json
 
-# claude
-.claude/**
+# claude (local settings stay ignored; project skills are versioned)
+.claude/*
+!.claude/skills
 
 # supabase
 supabase/.temp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ supabase/migrations
 types/database.types.ts
 components/ui/**
 components/ai-elements/**
+.claude/skills/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 
 ## Development Principles
 
+- Always apply the `ponytail` skill (`.claude/skills/ponytail`) on coding tasks: laziest working solution, YAGNI ladder, shortest diff that works. The full suite (`ponytail-review`, `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, `ponytail-help`) is available as project skills.
 - Prefer server-first architecture (RSC, minimal client-only code).
 - Keep data access in `server/` with `"use server"` and the correct Supabase client.
 - Favor explicit, typed, functional code over clever abstractions.

--- a/components/dashboard/broker-import/broker-transaction-results.test.tsx
+++ b/components/dashboard/broker-import/broker-transaction-results.test.tsx
@@ -71,8 +71,10 @@ describe("BrokerTransactionResults", () => {
         preview={preview}
         selectedSymbolTickers={{}}
         manualPositionKeys={[]}
+        excludedPositionKeys={[]}
         onSelectSymbol={vi.fn()}
         onToggleManual={vi.fn()}
+        onToggleExcluded={vi.fn()}
       />,
     );
 

--- a/components/dashboard/broker-import/broker-transaction-results.tsx
+++ b/components/dashboard/broker-import/broker-transaction-results.tsx
@@ -51,7 +51,8 @@ export function BrokerTransactionResults({
       <Alert className="text-green-600">
         <CheckCircle className="size-4" />
         <AlertTitle>
-          {formatBrokerSource(preview.source)} transaction CSV detected
+          {getBrokerDisplayName(preview.source) ?? preview.source} transaction
+          CSV detected
         </AlertTitle>
         <AlertDescription className="text-green-600">
           {preview.positionsToCreate.length} positions,{" "}
@@ -255,15 +256,4 @@ function SymbolReviewRow({
 
 function isIsinLike(value: string) {
   return /^[A-Z]{2}[A-Z0-9]{9}\d$/.test(value.trim().toUpperCase());
-}
-
-function formatBrokerSource(source: string) {
-  return (
-    getBrokerDisplayName(source) ??
-    source
-      .split("_")
-      .filter(Boolean)
-      .map((part) => part[0]?.toUpperCase() + part.slice(1))
-      .join(" ")
-  );
 }

--- a/components/dashboard/broker-import/broker-transaction-results.tsx
+++ b/components/dashboard/broker-import/broker-transaction-results.tsx
@@ -18,16 +18,20 @@ interface BrokerTransactionResultsProps {
   preview: Extract<BrokerTransactionImportPreview, { success: true }>;
   selectedSymbolTickers: Record<string, string>;
   manualPositionKeys: string[];
+  excludedPositionKeys: string[];
   onSelectSymbol: (positionKey: string, ticker: string) => void;
   onToggleManual: (positionKey: string) => void;
+  onToggleExcluded: (positionKey: string) => void;
 }
 
 export function BrokerTransactionResults({
   preview,
   selectedSymbolTickers,
   manualPositionKeys,
+  excludedPositionKeys,
   onSelectSymbol,
   onToggleManual,
+  onToggleExcluded,
 }: BrokerTransactionResultsProps) {
   const positionByKey = new Map(
     preview.positionsToCreate.map((position) => [
@@ -80,7 +84,9 @@ export function BrokerTransactionResults({
                 positionByKey.get(resolution.positionKey)?.currency ?? ""
               }
               selectedTicker={selectedSymbolTickers[resolution.positionKey]}
+              isExcluded={excludedPositionKeys.includes(resolution.positionKey)}
               onSelectSymbol={onSelectSymbol}
+              onToggleExcluded={onToggleExcluded}
             />
           ))}
         </div>
@@ -94,6 +100,9 @@ export function BrokerTransactionResults({
             const isManual = manualPositionKeys.includes(
               resolution.positionKey,
             );
+            const isExcluded = excludedPositionKeys.includes(
+              resolution.positionKey,
+            );
             const selectedTicker =
               selectedSymbolTickers[resolution.positionKey];
             return (
@@ -101,41 +110,54 @@ export function BrokerTransactionResults({
                 key={resolution.positionKey}
                 className="space-y-3 rounded-md border p-3"
               >
-                <div className="space-y-1">
-                  <div className="font-medium">{position?.name}</div>
-                  <div className="text-muted-foreground text-xs">
-                    {resolution.warning} Search a market symbol to link, or
-                    import as a manual position without market prices.
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <div className="font-medium">{position?.name}</div>
+                    <div className="text-muted-foreground text-xs">
+                      {isExcluded
+                        ? "This position and its transactions will not be imported. You can create it manually later."
+                        : `${resolution.warning} Search a market symbol to link, or import as a manual position without market prices.`}
+                    </div>
                   </div>
-                </div>
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                  <SymbolSearch
-                    field={{
-                      value: selectedTicker,
-                      // Linking a symbol and manual import are exclusive.
-                      onChange: (ticker) => {
-                        if (ticker && isManual) {
-                          onToggleManual(resolution.positionKey);
-                        }
-                        onSelectSymbol(resolution.positionKey, ticker);
-                      },
-                    }}
-                    className="w-full sm:flex-1"
-                  />
                   <Button
                     type="button"
-                    variant={isManual ? "secondary" : "outline"}
+                    variant={isExcluded ? "secondary" : "ghost"}
                     size="sm"
-                    onClick={() => {
-                      if (!isManual && selectedTicker) {
-                        onSelectSymbol(resolution.positionKey, "");
-                      }
-                      onToggleManual(resolution.positionKey);
-                    }}
+                    onClick={() => onToggleExcluded(resolution.positionKey)}
                   >
-                    {isManual ? "Manual selected" : "Import manually"}
+                    {isExcluded ? "Skipped" : "Skip"}
                   </Button>
                 </div>
+                {!isExcluded && (
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <SymbolSearch
+                      field={{
+                        value: selectedTicker,
+                        // Linking a symbol and manual import are exclusive.
+                        onChange: (ticker) => {
+                          if (ticker && isManual) {
+                            onToggleManual(resolution.positionKey);
+                          }
+                          onSelectSymbol(resolution.positionKey, ticker);
+                        },
+                      }}
+                      className="w-full sm:flex-1"
+                    />
+                    <Button
+                      type="button"
+                      variant={isManual ? "secondary" : "outline"}
+                      size="sm"
+                      onClick={() => {
+                        if (!isManual && selectedTicker) {
+                          onSelectSymbol(resolution.positionKey, "");
+                        }
+                        onToggleManual(resolution.positionKey);
+                      }}
+                    >
+                      {isManual ? "Manual selected" : "Import manually"}
+                    </Button>
+                  </div>
+                )}
               </div>
             );
           })}
@@ -165,14 +187,18 @@ function SymbolReviewRow({
   brokerSymbol,
   transactionCurrency,
   selectedTicker,
+  isExcluded,
   onSelectSymbol,
+  onToggleExcluded,
 }: {
   resolution: Extract<BrokerInstrumentResolution, { state: "needs_review" }>;
   positionName?: string;
   brokerSymbol?: string | null;
   transactionCurrency: string;
   selectedTicker?: string;
+  isExcluded: boolean;
   onSelectSymbol: (positionKey: string, ticker: string) => void;
+  onToggleExcluded: (positionKey: string) => void;
 }) {
   const brokerIdentifier = brokerSymbol
     ? `${isIsinLike(brokerSymbol) ? "ISIN" : "Broker symbol"} ${brokerSymbol}`
@@ -180,35 +206,49 @@ function SymbolReviewRow({
 
   return (
     <div className="space-y-3 rounded-md border p-3">
-      <div className="space-y-1">
-        <div className="font-medium">
-          {positionName ?? "Unknown position"}
-          {brokerIdentifier ? <span> - {brokerIdentifier}</span> : null}
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="font-medium">
+            {positionName ?? "Unknown position"}
+            {brokerIdentifier ? <span> - {brokerIdentifier}</span> : null}
+          </div>
+          <div className="text-muted-foreground text-xs">
+            {isExcluded
+              ? "This position and its transactions will not be imported. You can create it manually later."
+              : "Choose the market symbol to link. All transactions will be converted to that symbol currency before import."}
+          </div>
         </div>
-        <div className="text-muted-foreground text-xs">
-          Choose the market symbol to link. All transactions will be converted
-          to that symbol currency before import.
-        </div>
+        <Button
+          type="button"
+          variant={isExcluded ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => onToggleExcluded(resolution.positionKey)}
+        >
+          {isExcluded ? "Skipped" : "Skip"}
+        </Button>
       </div>
 
-      <SymbolSearch
-        field={{
-          value: selectedTicker,
-          onChange: (ticker) => onSelectSymbol(resolution.positionKey, ticker),
-        }}
-        className="w-full"
-        // Provider candidates seed the pre-search list; the currency slot
-        // flags listings that would trigger historical FX conversion.
-        defaultResults={resolution.candidates.map((candidate) => ({
-          id: candidate.ticker,
-          nameDisp: candidate.name,
-          exchange: candidate.exchange,
-          typeDisp:
-            candidate.currency === transactionCurrency
-              ? candidate.currency
-              : `${candidate.currency} · FX conversion`,
-        }))}
-      />
+      {!isExcluded && (
+        <SymbolSearch
+          field={{
+            value: selectedTicker,
+            onChange: (ticker) =>
+              onSelectSymbol(resolution.positionKey, ticker),
+          }}
+          className="w-full"
+          // Provider candidates seed the pre-search list; the currency slot
+          // flags listings that would trigger historical FX conversion.
+          defaultResults={resolution.candidates.map((candidate) => ({
+            id: candidate.ticker,
+            nameDisp: candidate.name,
+            exchange: candidate.exchange,
+            typeDisp:
+              candidate.currency === transactionCurrency
+                ? candidate.currency
+                : `${candidate.currency} · FX conversion`,
+          }))}
+        />
+      )}
     </div>
   );
 }

--- a/components/dashboard/broker-import/broker-transaction-results.tsx
+++ b/components/dashboard/broker-import/broker-transaction-results.tsx
@@ -13,6 +13,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+import { SymbolSearch } from "@/components/dashboard/symbol-search";
+
 import { getBrokerDisplayName } from "@/lib/import/broker-transactions/registry";
 
 import type {
@@ -100,25 +102,48 @@ export function BrokerTransactionResults({
             const isManual = manualPositionKeys.includes(
               resolution.positionKey,
             );
+            const selectedTicker =
+              selectedSymbolTickers[resolution.positionKey];
             return (
               <div
                 key={resolution.positionKey}
-                className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+                className="space-y-3 rounded-md border p-3"
               >
                 <div className="space-y-1">
                   <div className="font-medium">{position?.name}</div>
                   <div className="text-muted-foreground text-xs">
-                    {resolution.warning}
+                    {resolution.warning} Search a market symbol to link, or
+                    import as a manual position without market prices.
                   </div>
                 </div>
-                <Button
-                  type="button"
-                  variant={isManual ? "secondary" : "outline"}
-                  size="sm"
-                  onClick={() => onToggleManual(resolution.positionKey)}
-                >
-                  {isManual ? "Manual selected" : "Import manually"}
-                </Button>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <SymbolSearch
+                    field={{
+                      value: selectedTicker,
+                      // Linking a symbol and manual import are exclusive.
+                      onChange: (ticker) => {
+                        if (ticker && isManual) {
+                          onToggleManual(resolution.positionKey);
+                        }
+                        onSelectSymbol(resolution.positionKey, ticker);
+                      },
+                    }}
+                    className="w-full sm:flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant={isManual ? "secondary" : "outline"}
+                    size="sm"
+                    onClick={() => {
+                      if (!isManual && selectedTicker) {
+                        onSelectSymbol(resolution.positionKey, "");
+                      }
+                      onToggleManual(resolution.positionKey);
+                    }}
+                  >
+                    {isManual ? "Manual selected" : "Import manually"}
+                  </Button>
+                </div>
               </div>
             );
           })}
@@ -199,6 +224,20 @@ function SymbolReviewRow({
           </SelectContent>
         </Select>
       )}
+
+      <div className="space-y-1">
+        <div className="text-muted-foreground text-xs">
+          Not the listing you trade? Search any market symbol instead.
+        </div>
+        <SymbolSearch
+          field={{
+            value: selectedTicker,
+            onChange: (ticker) =>
+              onSelectSymbol(resolution.positionKey, ticker),
+          }}
+          className="w-full"
+        />
+      </div>
     </div>
   );
 }

--- a/components/dashboard/broker-import/broker-transaction-results.tsx
+++ b/components/dashboard/broker-import/broker-transaction-results.tsx
@@ -186,9 +186,8 @@ function SymbolReviewRow({
           {brokerIdentifier ? <span> - {brokerIdentifier}</span> : null}
         </div>
         <div className="text-muted-foreground text-xs">
-          Choose the market symbol to link. Suggested listings are shown first;
-          type to search any other symbol. All transactions will be converted to
-          that symbol currency before import.
+          Choose the market symbol to link. All transactions will be converted
+          to that symbol currency before import.
         </div>
       </div>
 

--- a/components/dashboard/broker-import/broker-transaction-results.tsx
+++ b/components/dashboard/broker-import/broker-transaction-results.tsx
@@ -221,7 +221,7 @@ function SymbolReviewRow({
         <Button
           type="button"
           variant={isExcluded ? "secondary" : "ghost"}
-          size="sm"
+          size="xs"
           onClick={() => onToggleExcluded(resolution.positionKey)}
         >
           {isExcluded ? "Skipped" : "Skip"}

--- a/components/dashboard/broker-import/broker-transaction-results.tsx
+++ b/components/dashboard/broker-import/broker-transaction-results.tsx
@@ -1,19 +1,9 @@
 "use client";
 
-import { useState } from "react";
 import { AlertCircle, CheckCircle } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 
 import { SymbolSearch } from "@/components/dashboard/symbol-search";
 
@@ -23,10 +13,6 @@ import type {
   BrokerInstrumentResolution,
   BrokerTransactionImportPreview,
 } from "@/server/import/broker-transactions/instrument-resolution";
-
-// Sentinel select value; never a real ticker because tickers cannot contain
-// spaces.
-const SEARCH_INSTEAD_VALUE = "__search instead__";
 
 interface BrokerTransactionResultsProps {
   preview: Extract<BrokerTransactionImportPreview, { success: true }>;
@@ -188,11 +174,6 @@ function SymbolReviewRow({
   selectedTicker?: string;
   onSelectSymbol: (positionKey: string, ticker: string) => void;
 }) {
-  // Free symbol search hides behind a "Can't find your symbol?" select entry
-  // so the default flow stays a single dropdown of provider candidates.
-  const [isSearchMode, setIsSearchMode] = useState(
-    resolution.candidates.length === 0,
-  );
   const brokerIdentifier = brokerSymbol
     ? `${isIsinLike(brokerSymbol) ? "ISIN" : "Broker symbol"} ${brokerSymbol}`
     : null;
@@ -205,68 +186,30 @@ function SymbolReviewRow({
           {brokerIdentifier ? <span> - {brokerIdentifier}</span> : null}
         </div>
         <div className="text-muted-foreground text-xs">
-          Choose the market symbol to link. All transactions will be converted
-          to that symbol currency before import.
+          Choose the market symbol to link. Suggested listings are shown first;
+          type to search any other symbol. All transactions will be converted to
+          that symbol currency before import.
         </div>
       </div>
 
-      {!isSearchMode ? (
-        <Select
-          value={selectedTicker ?? ""}
-          onValueChange={(ticker) => {
-            if (ticker === SEARCH_INSTEAD_VALUE) {
-              onSelectSymbol(resolution.positionKey, "");
-              setIsSearchMode(true);
-              return;
-            }
-            onSelectSymbol(resolution.positionKey, ticker);
-          }}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Choose symbol" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              {resolution.candidates.map((candidate) => (
-                <SelectItem key={candidate.ticker} value={candidate.ticker}>
-                  {candidate.ticker} ({candidate.currency})
-                  {candidate.exchange ? ` - ${candidate.exchange}` : ""}
-                  {candidate.currency === transactionCurrency
-                    ? ""
-                    : " (FX conversion)"}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-            <SelectSeparator />
-            <SelectItem value={SEARCH_INSTEAD_VALUE}>
-              Can&apos;t find your symbol? Search instead
-            </SelectItem>
-          </SelectContent>
-        </Select>
-      ) : (
-        <div className="space-y-1">
-          <SymbolSearch
-            field={{
-              value: selectedTicker,
-              onChange: (ticker) =>
-                onSelectSymbol(resolution.positionKey, ticker),
-            }}
-            className="w-full"
-          />
-          {resolution.candidates.length > 0 && (
-            <button
-              type="button"
-              className="text-muted-foreground hover:text-foreground text-xs underline underline-offset-4"
-              onClick={() => {
-                onSelectSymbol(resolution.positionKey, "");
-                setIsSearchMode(false);
-              }}
-            >
-              Back to suggested symbols
-            </button>
-          )}
-        </div>
-      )}
+      <SymbolSearch
+        field={{
+          value: selectedTicker,
+          onChange: (ticker) => onSelectSymbol(resolution.positionKey, ticker),
+        }}
+        className="w-full"
+        // Provider candidates seed the pre-search list; the currency slot
+        // flags listings that would trigger historical FX conversion.
+        defaultResults={resolution.candidates.map((candidate) => ({
+          id: candidate.ticker,
+          nameDisp: candidate.name,
+          exchange: candidate.exchange,
+          typeDisp:
+            candidate.currency === transactionCurrency
+              ? candidate.currency
+              : `${candidate.currency} · FX conversion`,
+        }))}
+      />
     </div>
   );
 }

--- a/components/dashboard/broker-import/broker-transaction-results.tsx
+++ b/components/dashboard/broker-import/broker-transaction-results.tsx
@@ -13,6 +13,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+import { getBrokerDisplayName } from "@/lib/import/broker-transactions/registry";
+
 import type {
   BrokerInstrumentResolution,
   BrokerTransactionImportPreview,
@@ -206,10 +208,12 @@ function isIsinLike(value: string) {
 }
 
 function formatBrokerSource(source: string) {
-  if (source === "trade_republic") return "Trade Republic";
-  return source
-    .split("_")
-    .filter(Boolean)
-    .map((part) => part[0]?.toUpperCase() + part.slice(1))
-    .join(" ");
+  return (
+    getBrokerDisplayName(source) ??
+    source
+      .split("_")
+      .filter(Boolean)
+      .map((part) => part[0]?.toUpperCase() + part.slice(1))
+      .join(" ")
+  );
 }

--- a/components/dashboard/broker-import/broker-transaction-results.tsx
+++ b/components/dashboard/broker-import/broker-transaction-results.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { AlertCircle, CheckCircle } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -9,6 +10,7 @@ import {
   SelectContent,
   SelectGroup,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -21,6 +23,10 @@ import type {
   BrokerInstrumentResolution,
   BrokerTransactionImportPreview,
 } from "@/server/import/broker-transactions/instrument-resolution";
+
+// Sentinel select value; never a real ticker because tickers cannot contain
+// spaces.
+const SEARCH_INSTEAD_VALUE = "__search instead__";
 
 interface BrokerTransactionResultsProps {
   preview: Extract<BrokerTransactionImportPreview, { success: true }>;
@@ -182,6 +188,11 @@ function SymbolReviewRow({
   selectedTicker?: string;
   onSelectSymbol: (positionKey: string, ticker: string) => void;
 }) {
+  // Free symbol search hides behind a "Can't find your symbol?" select entry
+  // so the default flow stays a single dropdown of provider candidates.
+  const [isSearchMode, setIsSearchMode] = useState(
+    resolution.candidates.length === 0,
+  );
   const brokerIdentifier = brokerSymbol
     ? `${isIsinLike(brokerSymbol) ? "ISIN" : "Broker symbol"} ${brokerSymbol}`
     : null;
@@ -199,12 +210,17 @@ function SymbolReviewRow({
         </div>
       </div>
 
-      {resolution.candidates.length > 0 && (
+      {!isSearchMode ? (
         <Select
           value={selectedTicker ?? ""}
-          onValueChange={(ticker) =>
-            onSelectSymbol(resolution.positionKey, ticker)
-          }
+          onValueChange={(ticker) => {
+            if (ticker === SEARCH_INSTEAD_VALUE) {
+              onSelectSymbol(resolution.positionKey, "");
+              setIsSearchMode(true);
+              return;
+            }
+            onSelectSymbol(resolution.positionKey, ticker);
+          }}
         >
           <SelectTrigger className="w-full">
             <SelectValue placeholder="Choose symbol" />
@@ -221,23 +237,36 @@ function SymbolReviewRow({
                 </SelectItem>
               ))}
             </SelectGroup>
+            <SelectSeparator />
+            <SelectItem value={SEARCH_INSTEAD_VALUE}>
+              Can&apos;t find your symbol? Search instead
+            </SelectItem>
           </SelectContent>
         </Select>
-      )}
-
-      <div className="space-y-1">
-        <div className="text-muted-foreground text-xs">
-          Not the listing you trade? Search any market symbol instead.
+      ) : (
+        <div className="space-y-1">
+          <SymbolSearch
+            field={{
+              value: selectedTicker,
+              onChange: (ticker) =>
+                onSelectSymbol(resolution.positionKey, ticker),
+            }}
+            className="w-full"
+          />
+          {resolution.candidates.length > 0 && (
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground text-xs underline underline-offset-4"
+              onClick={() => {
+                onSelectSymbol(resolution.positionKey, "");
+                setIsSearchMode(false);
+              }}
+            >
+              Back to suggested symbols
+            </button>
+          )}
         </div>
-        <SymbolSearch
-          field={{
-            value: selectedTicker,
-            onChange: (ticker) =>
-              onSelectSymbol(resolution.positionKey, ticker),
-          }}
-          className="w-full"
-        />
-      </div>
+      )}
     </div>
   );
 }

--- a/components/dashboard/broker-import/csv-form.tsx
+++ b/components/dashboard/broker-import/csv-form.tsx
@@ -42,7 +42,12 @@ export function BrokerImportCSVForm() {
       if (resolution.state === "needs_review") {
         return Boolean(selectedSymbolTickers[resolution.positionKey]);
       }
-      return manualPositionKeys.includes(resolution.positionKey);
+      // Unresolved positions import either with a user-searched symbol or as
+      // a manual position.
+      return (
+        manualPositionKeys.includes(resolution.positionKey) ||
+        Boolean(selectedSymbolTickers[resolution.positionKey])
+      );
     });
   }, [manualPositionKeys, preview, selectedSymbolTickers]);
 

--- a/components/dashboard/broker-import/csv-form.tsx
+++ b/components/dashboard/broker-import/csv-form.tsx
@@ -16,6 +16,7 @@ import {
   importBrokerTransactionsFromCSV,
   previewBrokerImport,
 } from "@/server/import/broker-transactions/import";
+import { listSupportedBrokerDisplayNames } from "@/lib/import/broker-transactions/registry";
 
 import type { BrokerTransactionImportPreview } from "@/server/import/broker-transactions/instrument-resolution";
 
@@ -109,9 +110,12 @@ export function BrokerImportCSVForm() {
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <DialogBody className="space-y-4">
         <div className="text-muted-foreground text-sm">
-          Only{" "}
-          <span className="text-foreground font-medium">Trade Republic</span> is
-          currently supported. Upload its transaction CSV, review the matched
+          <span className="text-foreground font-medium">
+            {new Intl.ListFormat("en").format(
+              listSupportedBrokerDisplayNames(),
+            )}
+          </span>{" "}
+          are currently supported. Upload a transaction CSV, review the matched
           symbols, and Foliofox will create positions, import transactions, and
           skip records already imported.
         </div>
@@ -129,7 +133,7 @@ export function BrokerImportCSVForm() {
           isProcessing={isProcessing}
           onReset={handleReset}
           disabled={isImporting}
-          title="Drop your Trade Republic CSV file here"
+          title="Drop your broker CSV file here"
         />
 
         {preview?.success ? (

--- a/components/dashboard/broker-import/csv-form.tsx
+++ b/components/dashboard/broker-import/csv-form.tsx
@@ -33,11 +33,15 @@ export function BrokerImportCSVForm() {
     Record<string, string>
   >({});
   const [manualPositionKeys, setManualPositionKeys] = useState<string[]>([]);
+  const [excludedPositionKeys, setExcludedPositionKeys] = useState<string[]>(
+    [],
+  );
 
   const canImport = useMemo(() => {
     if (!preview?.success) return false;
 
     return preview.resolutions.every((resolution) => {
+      if (excludedPositionKeys.includes(resolution.positionKey)) return true;
       if (resolution.state === "auto_linked") return true;
       if (resolution.state === "needs_review") {
         return Boolean(selectedSymbolTickers[resolution.positionKey]);
@@ -49,7 +53,12 @@ export function BrokerImportCSVForm() {
         Boolean(selectedSymbolTickers[resolution.positionKey])
       );
     });
-  }, [manualPositionKeys, preview, selectedSymbolTickers]);
+  }, [
+    excludedPositionKeys,
+    manualPositionKeys,
+    preview,
+    selectedSymbolTickers,
+  ]);
 
   const handleFileSelect = useCallback(async (file: File, content: string) => {
     setSelectedFile(file);
@@ -57,6 +66,7 @@ export function BrokerImportCSVForm() {
     setPreview(null);
     setSelectedSymbolTickers({});
     setManualPositionKeys([]);
+    setExcludedPositionKeys([]);
     setIsProcessing(true);
 
     try {
@@ -83,6 +93,7 @@ export function BrokerImportCSVForm() {
       const result = await importBrokerTransactionsFromCSV(csvContent, {
         selectedSymbolTickers,
         manualPositionKeys,
+        excludedPositionKeys,
       });
 
       if (!result.success) {
@@ -109,6 +120,7 @@ export function BrokerImportCSVForm() {
     setPreview(null);
     setSelectedSymbolTickers({});
     setManualPositionKeys([]);
+    setExcludedPositionKeys([]);
   };
 
   return (
@@ -146,6 +158,14 @@ export function BrokerImportCSVForm() {
             preview={preview}
             selectedSymbolTickers={selectedSymbolTickers}
             manualPositionKeys={manualPositionKeys}
+            excludedPositionKeys={excludedPositionKeys}
+            onToggleExcluded={(positionKey) =>
+              setExcludedPositionKeys((current) =>
+                current.includes(positionKey)
+                  ? current.filter((key) => key !== positionKey)
+                  : [...current, positionKey],
+              )
+            }
             onSelectSymbol={(positionKey, ticker) =>
               setSelectedSymbolTickers((current) => ({
                 ...current,

--- a/components/dashboard/broker-import/index.tsx
+++ b/components/dashboard/broker-import/index.tsx
@@ -53,7 +53,8 @@ export function BrokerImportDialogProvider({
     <BrokerImportDialogContext.Provider value={{ open, setOpen }}>
       {children}
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
+        {/* Review selections are easy to lose; close only via the buttons. */}
+        <DialogContent onInteractOutside={(event) => event.preventDefault()}>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Upload className="size-5" />

--- a/components/dashboard/symbol-search.tsx
+++ b/components/dashboard/symbol-search.tsx
@@ -73,6 +73,10 @@ interface SymbolSearchProps {
   onSymbolSelect?: (symbolId: string) => void;
   className?: string;
   popoverWidth?: string;
+  // Shown before the user types, instead of the generic popular symbols.
+  // Used by flows that have context-specific suggestions (e.g. broker import
+  // ISIN candidates).
+  defaultResults?: SymbolSearchResult[];
 }
 
 export function SymbolSearch({
@@ -84,6 +88,7 @@ export function SymbolSearch({
   onSymbolSelect,
   className,
   popoverWidth = "w-(--radix-popover-trigger-width)",
+  defaultResults,
 }: SymbolSearchProps) {
   const [open, setOpen] = useState(false);
   const [results, setResults] = useState<SymbolSearchResult[]>([]);
@@ -91,7 +96,9 @@ export function SymbolSearch({
   const [isLoadingQuote, setIsLoadingQuote] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery] = useDebounce(searchQuery, 300);
-  const displayedResults = debouncedQuery ? results : POPULAR_SYMBOL_RESULTS;
+  const displayedResults = debouncedQuery
+    ? results
+    : (defaultResults ?? POPULAR_SYMBOL_RESULTS);
 
   // Find the selected equity
   const selectedSymbol = displayedResults.find(

--- a/components/dashboard/symbol-search.tsx
+++ b/components/dashboard/symbol-search.tsx
@@ -307,18 +307,18 @@ function SymbolList({
               disabled={isLoadingQuote}
               className="flex flex-row justify-between gap-4 [&>svg:last-child]:hidden"
             >
-              <div className="flex flex-col">
-                <span>{symbol.id}</span>
-                <span className="text-muted-foreground text-xs">
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate">{symbol.id}</span>
+                <span className="text-muted-foreground truncate text-xs">
                   {symbol.nameDisp}
                 </span>
               </div>
-              <div className="flex flex-row gap-2">
+              <div className="flex shrink-0 flex-row gap-2">
                 <div className="flex flex-col items-end">
-                  <span className="text-muted-foreground text-xs">
+                  <span className="text-muted-foreground text-xs whitespace-nowrap">
                     {symbol.exchange}
                   </span>
-                  <span className="text-muted-foreground text-xs">
+                  <span className="text-muted-foreground text-xs whitespace-nowrap">
                     {symbol.typeDisp}
                   </span>
                 </div>

--- a/components/dashboard/symbol-search.tsx
+++ b/components/dashboard/symbol-search.tsx
@@ -314,7 +314,7 @@ function SymbolList({
                 </span>
               </div>
               <div className="flex shrink-0 flex-row gap-2">
-                <div className="flex flex-col items-end">
+                <div className="flex flex-col items-end gap-1">
                   <span className="text-muted-foreground text-xs whitespace-nowrap">
                     {symbol.exchange}
                   </span>

--- a/components/dashboard/symbol-search.tsx
+++ b/components/dashboard/symbol-search.tsx
@@ -263,7 +263,9 @@ function SymbolList({
         onValueChange={setSearchQuery}
         disabled={isLoadingQuote}
       />
-      <CommandList>
+      {/* Result rows are ~52px; the default max-h-72 clips the 6th row
+          mid-item with no visible scrollbar. 384px fits 7 rows cleanly. */}
+      <CommandList className="max-h-96">
         <CommandEmpty>
           {isLoading ? (
             "Searching..."

--- a/docs/broker-transaction-csv-import-plan.md
+++ b/docs/broker-transaction-csv-import-plan.md
@@ -127,9 +127,16 @@ Keep Foliofox’s model unchanged: positions are holdings, records are transacti
 - Unit test broker FX conversion for different-currency symbol selections and existing matched positions.
 - Verify with targeted `vitest`, type check, and lint only. No Supabase CLI, Next CLI, database commands, or production-system commands.
 
+## Supported Adapters
+
+- `trade_republic`: English transaction export; broker-provided `transaction_id`.
+- `scalable_capital`: semicolon CSV (`date;description;type;isin;shares;price;amount;fee;tax;currency`), EU decimals; `Buy`/`Sell`/`Savings plan` rows import, cash rows ignored. No per-row ID, so external transaction IDs are synthesized from normalized row content plus an occurrence suffix for identical rows.
+- `directa`: Italian "Movimenti" export with metadata preamble before the header row; `Acquisto`/`Vendita` import, `Commissioni` ignored. Unit price is derived from amount ÷ quantity (`Importo Divisa` for non-EUR trades). `Riferimento ordine` is per-order and Excel-mangled in the wild, so IDs are synthesized the same way as Scalable Capital.
+- Adapters own their detection (`detect(csvContent)`) and stay self-contained by design: a broker changing its export format is patched in that adapter file and its test only.
+
 ## Assumptions
 
-- V1 supports Trade Republic only; new brokers are added as new adapters.
+- New brokers are added as new adapters in `lib/import/broker-transactions/adapters/`.
 - Fees, dividends, interest, taxes, and cash movements are ignored in v1 with warnings.
 - Trade Republic trading rows may use broker venue currency rather than the instrument home-listing currency; auto-linking must be currency-safe.
 - Users expect broker-imported positions to become symbol-backed when safe, but correctness is more important than silently linking the wrong quote currency.

--- a/lib/import/broker-transactions/adapter-utils.test.ts
+++ b/lib/import/broker-transactions/adapter-utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { inferOpeningQuantity } from "./adapter-utils";
+import {
+  assignFileOrderExecutedAt,
+  inferOpeningQuantity,
+} from "./adapter-utils";
 
 import type { BrokerTransactionRecordDraft } from "./types";
 
@@ -21,6 +24,21 @@ function record(
     ...overrides,
   };
 }
+
+describe("assignFileOrderExecutedAt", () => {
+  it("treats single-date files as newest-first", () => {
+    // A same-day sell listed above its buy in a newest-first export happened
+    // after the buy; keeping file order would fabricate an opening shortfall.
+    const records = [
+      record({ type: "sell", sourceRowNumber: 2 }),
+      record({ type: "buy", sourceRowNumber: 3 }),
+    ];
+
+    assignFileOrderExecutedAt(records);
+
+    expect(records[0].executedAt! > records[1].executedAt!).toBe(true);
+  });
+});
 
 describe("inferOpeningQuantity", () => {
   it("returns zero for a self-contained buy/sell history", () => {

--- a/lib/import/broker-transactions/adapter-utils.test.ts
+++ b/lib/import/broker-transactions/adapter-utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { inferOpeningQuantity } from "./adapter-utils";
+
+import type { BrokerTransactionRecordDraft } from "./types";
+
+function record(
+  overrides: Partial<BrokerTransactionRecordDraft>,
+): BrokerTransactionRecordDraft {
+  return {
+    source: "scalable_capital",
+    positionKey: "key",
+    positionName: "World ETF",
+    type: "buy",
+    date: "2026-01-01",
+    quantity: 1,
+    unit_value: 10,
+    description: null,
+    external_transaction_id: "id",
+    sourceRowNumber: 2,
+    ...overrides,
+  };
+}
+
+describe("inferOpeningQuantity", () => {
+  it("returns zero for a self-contained buy/sell history", () => {
+    expect(
+      inferOpeningQuantity([
+        record({ type: "buy", date: "2026-01-01", quantity: 5 }),
+        record({ type: "sell", date: "2026-02-01", quantity: 5 }),
+      ]),
+    ).toBe(0);
+  });
+
+  it("covers a sell that has no buys in the export window", () => {
+    expect(
+      inferOpeningQuantity([
+        record({ type: "sell", date: "2026-01-01", quantity: 3 }),
+      ]),
+    ).toBe(3);
+  });
+
+  it("covers the largest shortfall across an interleaved history", () => {
+    // Chronologically: sell 2 (short 2), buy 5 (up 3), sell 4 (short 1 more
+    // than covered → total shortfall stays 2). Records passed out of order to
+    // prove sorting by date.
+    expect(
+      inferOpeningQuantity([
+        record({ type: "sell", date: "2026-03-01", quantity: 4 }),
+        record({ type: "buy", date: "2026-02-01", quantity: 5 }),
+        record({ type: "sell", date: "2026-01-01", quantity: 2 }),
+      ]),
+    ).toBe(2);
+  });
+});

--- a/lib/import/broker-transactions/adapter-utils.ts
+++ b/lib/import/broker-transactions/adapter-utils.ts
@@ -73,7 +73,10 @@ export function assignFileOrderExecutedAt(
 ) {
   if (records.length === 0) return;
 
-  const isChronological = records[0].date <= records[records.length - 1].date;
+  // Strictly less: a single-date file cannot reveal its direction, and the
+  // supported brokers export newest-first, so date ties are treated as
+  // newest-first instead of keeping file order.
+  const isChronological = records[0].date < records[records.length - 1].date;
   records.forEach((record, index) => {
     const offsetMs = isChronological ? index : records.length - 1 - index;
     record.executedAt = new Date(

--- a/lib/import/broker-transactions/adapter-utils.ts
+++ b/lib/import/broker-transactions/adapter-utils.ts
@@ -21,6 +21,47 @@ export function createSyntheticTransactionIdFactory() {
   };
 }
 
+export function compareBrokerRecordOrder(
+  left: BrokerTransactionRecordDraft,
+  right: BrokerTransactionRecordDraft,
+) {
+  if (left.date !== right.date) {
+    return left.date.localeCompare(right.date);
+  }
+
+  const leftTime = left.executedAt ?? "";
+  const rightTime = right.executedAt ?? "";
+  if (leftTime !== rightTime) {
+    return leftTime.localeCompare(rightTime);
+  }
+
+  return left.sourceRowNumber - right.sourceRowNumber;
+}
+
+/**
+ * Infer the pre-history holding for a position from its parsed records.
+ *
+ * Date-ranged broker exports can contain sells whose buys happened before the
+ * export window. The largest running shortfall is the minimum quantity the
+ * user must have held before the first record; importing starts the position
+ * from that opening balance instead of zero so the timeline stays valid.
+ */
+export function inferOpeningQuantity(
+  records: BrokerTransactionRecordDraft[],
+): number {
+  let runningQuantity = 0;
+  let largestShortfall = 0;
+
+  for (const record of [...records].sort(compareBrokerRecordOrder)) {
+    runningQuantity +=
+      record.type === "sell" ? -record.quantity : record.quantity;
+    largestShortfall = Math.min(largestShortfall, runningQuantity);
+  }
+
+  // Math.max also normalizes the no-shortfall case away from -0.
+  return Math.max(0, -largestShortfall);
+}
+
 /**
  * Synthesize `executedAt` from file order for exports without execution
  * timestamps. Same-date trades otherwise fall back to ascending row number,

--- a/lib/import/broker-transactions/adapter-utils.ts
+++ b/lib/import/broker-transactions/adapter-utils.ts
@@ -1,0 +1,42 @@
+import { parseUTCDateKey } from "@/lib/date/date-utils";
+
+import type { BrokerTransactionRecordDraft } from "./types";
+
+/**
+ * Deterministic transaction IDs for brokers whose exports carry no per-row ID.
+ *
+ * The ID is built from normalized (parsed) row values, so cosmetic formatting
+ * changes in future exports ("2500,5" vs "2500,50") keep the same ID and
+ * re-uploads stay idempotent. Identical rows (e.g. two equal fills of one
+ * order) get an occurrence suffix so both import.
+ */
+export function createSyntheticTransactionIdFactory() {
+  const occurrences = new Map<string, number>();
+
+  return (parts: Array<string | number>): string => {
+    const key = parts.map((part) => String(part)).join("|");
+    const occurrence = (occurrences.get(key) ?? 0) + 1;
+    occurrences.set(key, occurrence);
+    return `${key}#${occurrence}`;
+  };
+}
+
+/**
+ * Synthesize `executedAt` from file order for exports without execution
+ * timestamps. Same-date trades otherwise fall back to ascending row number,
+ * which is reverse-chronological in the usual newest-first broker exports and
+ * can misorder same-day buy/sell sequences during import.
+ */
+export function assignFileOrderExecutedAt(
+  records: BrokerTransactionRecordDraft[],
+) {
+  if (records.length === 0) return;
+
+  const isChronological = records[0].date <= records[records.length - 1].date;
+  records.forEach((record, index) => {
+    const offsetMs = isChronological ? index : records.length - 1 - index;
+    record.executedAt = new Date(
+      parseUTCDateKey(record.date).getTime() + offsetMs,
+    ).toISOString();
+  });
+}

--- a/lib/import/broker-transactions/adapters/directa.ts
+++ b/lib/import/broker-transactions/adapters/directa.ts
@@ -181,6 +181,14 @@ export const directaAdapter: BrokerTransactionAdapter = {
       const signedQuantity = type === "sell" ? -quantity : quantity;
 
       if (existingPosition) {
+        // Records carry no per-row currency, so one instrument trading in two
+        // currencies within a file cannot be priced safely.
+        if (existingPosition.currency !== currency) {
+          errors.push(
+            `Row ${rowNumber}: "${name}" mixes trade currencies (${existingPosition.currency} and ${currency}), which is not supported yet`,
+          );
+          continue;
+        }
         existingPosition.endingQuantity = normalizeEndingQuantity(
           existingPosition.endingQuantity + signedQuantity,
         );

--- a/lib/import/broker-transactions/adapters/directa.ts
+++ b/lib/import/broker-transactions/adapters/directa.ts
@@ -110,9 +110,6 @@ export const directaAdapter: BrokerTransactionAdapter = {
       parsedTable.table.normalizedHeaders.find((header) =>
         header.startsWith("quantit"),
       ) ?? "quantita";
-    // Best-effort mapping of table rows back to original file lines for errors.
-    const rowNumberOffset = headerRecordIndex;
-
     const positionsByKey = new Map<string, BrokerTransactionPositionDraft>();
     const records: BrokerTransactionRecordDraft[] = [];
     const errors: string[] = [];
@@ -121,12 +118,12 @@ export const directaAdapter: BrokerTransactionAdapter = {
     // and is often mangled into scientific notation by Excel round-trips, so
     // IDs are derived from normalized row content instead.
     const buildTransactionId = createSyntheticTransactionIdFactory();
-    let ignoredRowCount = 0;
     let ignoredFeeRowCount = 0;
     let ignoredOtherRowCount = 0;
 
     for (const row of parsedTable.table.rows) {
-      const rowNumber = row.rowNumber + rowNumberOffset;
+      // Best-effort mapping of table rows back to original file lines for errors.
+      const rowNumber = row.rowNumber + headerRecordIndex;
       const rawType = row.get("tipo_operazione").trim().toLowerCase();
 
       if (!BUY_TYPES.has(rawType) && !SELL_TYPES.has(rawType)) {
@@ -135,7 +132,6 @@ export const directaAdapter: BrokerTransactionAdapter = {
         } else {
           ignoredOtherRowCount++;
         }
-        ignoredRowCount++;
         continue;
       }
 
@@ -245,7 +241,7 @@ export const directaAdapter: BrokerTransactionAdapter = {
       source: SOURCE,
       positions: Array.from(positionsByKey.values()),
       records,
-      ignoredRowCount,
+      ignoredRowCount: ignoredFeeRowCount + ignoredOtherRowCount,
       duplicateTransactionIdCount: 0,
       warnings: warnings.length > 0 ? warnings : undefined,
       errors: errors.length > 0 ? errors : undefined,

--- a/lib/import/broker-transactions/adapters/directa.ts
+++ b/lib/import/broker-transactions/adapters/directa.ts
@@ -1,0 +1,254 @@
+import { parseUTCDateKey } from "@/lib/date/date-utils";
+import { parseNumberStrict } from "@/lib/import/shared/number-parser";
+import {
+  parseCSVRowValues,
+  splitCSVRecords,
+} from "@/lib/import/shared/csv-parser-utils";
+
+import {
+  assignFileOrderExecutedAt,
+  createSyntheticTransactionIdFactory,
+} from "../adapter-utils";
+import { normalizeBrokerHeader, parseBrokerTransactionCSVTable } from "../csv";
+
+import type {
+  BrokerTransactionAdapter,
+  BrokerTransactionImportResult,
+  BrokerTransactionPositionDraft,
+  BrokerTransactionRecordDraft,
+} from "../types";
+
+const SOURCE = "directa";
+const DISPLAY_NAME = "Directa";
+// "Quantità" is matched by prefix because a Windows-1252 export decoded as
+// UTF-8 mangles the accented character.
+const REQUIRED_HEADERS = [
+  "data_operazione",
+  "tipo_operazione",
+  "isin",
+  "descrizione",
+  "importo_euro",
+  "divisa",
+];
+const BUY_TYPES = new Set(["acquisto"]);
+const SELL_TYPES = new Set(["vendita"]);
+const FEE_TYPES = new Set(["commissioni"]);
+const ZERO_EPSILON = 1e-9;
+
+function normalizeKeyPart(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function buildPositionKey(name: string, isin: string): string {
+  const symbolPart = isin.trim() || normalizeKeyPart(name);
+  return `${SOURCE}:${normalizeKeyPart(symbolPart)}:${normalizeKeyPart(name)}`;
+}
+
+function normalizeEndingQuantity(quantity: number): number {
+  return Math.abs(quantity) < ZERO_EPSILON ? 0 : quantity;
+}
+
+function isDirectaHeaderRecord(record: string): boolean {
+  const headers = parseCSVRowValues(record, ";").map(normalizeBrokerHeader);
+  return (
+    REQUIRED_HEADERS.every((header) => headers.includes(header)) &&
+    headers.some((header) => header.startsWith("quantit"))
+  );
+}
+
+// Directa "Movimenti" exports start with account metadata lines before the
+// real header row, so the adapter locates the header instead of assuming
+// it is the first line.
+function findHeaderRecordIndex(csvContent: string): number {
+  return splitCSVRecords(csvContent).findIndex(isDirectaHeaderRecord);
+}
+
+// Directa dates are dd/mm/yyyy.
+function parseDirectaDateKey(raw: string): string | null {
+  const match = raw.trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (!match) return null;
+
+  const dateKey = `${match[3]}-${match[2].padStart(2, "0")}-${match[1].padStart(2, "0")}`;
+  return Number.isNaN(parseUTCDateKey(dateKey).getTime()) ? null : dateKey;
+}
+
+export const directaAdapter: BrokerTransactionAdapter = {
+  source: SOURCE,
+  displayName: DISPLAY_NAME,
+  detect: (csvContent) => findHeaderRecordIndex(csvContent) >= 0,
+  async parse(csvContent: string): Promise<BrokerTransactionImportResult> {
+    const headerRecordIndex = findHeaderRecordIndex(csvContent);
+    if (headerRecordIndex < 0) {
+      return {
+        success: false,
+        source: SOURCE,
+        positions: [],
+        records: [],
+        ignoredRowCount: 0,
+        duplicateTransactionIdCount: 0,
+        errors: ["CSV file does not match the Directa export format"],
+      };
+    }
+
+    const parsedTable = parseBrokerTransactionCSVTable(
+      splitCSVRecords(csvContent).slice(headerRecordIndex).join("\n"),
+    );
+    if (!parsedTable.success) {
+      return {
+        success: false,
+        source: SOURCE,
+        positions: [],
+        records: [],
+        ignoredRowCount: 0,
+        duplicateTransactionIdCount: 0,
+        errors: parsedTable.errors,
+      };
+    }
+
+    // Resolve the possibly mangled quantity header once (see REQUIRED_HEADERS).
+    const quantityHeader =
+      parsedTable.table.normalizedHeaders.find((header) =>
+        header.startsWith("quantit"),
+      ) ?? "quantita";
+    // Best-effort mapping of table rows back to original file lines for errors.
+    const rowNumberOffset = headerRecordIndex;
+
+    const positionsByKey = new Map<string, BrokerTransactionPositionDraft>();
+    const records: BrokerTransactionRecordDraft[] = [];
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    // Directa's "Riferimento ordine" is per-order (shared by multiple fills)
+    // and is often mangled into scientific notation by Excel round-trips, so
+    // IDs are derived from normalized row content instead.
+    const buildTransactionId = createSyntheticTransactionIdFactory();
+    let ignoredRowCount = 0;
+    let ignoredFeeRowCount = 0;
+    let ignoredOtherRowCount = 0;
+
+    for (const row of parsedTable.table.rows) {
+      const rowNumber = row.rowNumber + rowNumberOffset;
+      const rawType = row.get("tipo_operazione").trim().toLowerCase();
+
+      if (!BUY_TYPES.has(rawType) && !SELL_TYPES.has(rawType)) {
+        if (FEE_TYPES.has(rawType)) {
+          ignoredFeeRowCount++;
+        } else {
+          ignoredOtherRowCount++;
+        }
+        ignoredRowCount++;
+        continue;
+      }
+
+      const name = row.get("descrizione").trim();
+      const isin = row.get("isin").trim().toUpperCase();
+      const dateRaw = row.get("data_operazione").trim();
+      const dateKey = parseDirectaDateKey(dateRaw);
+      const quantity = Math.abs(parseNumberStrict(row.get(quantityHeader)));
+      const currency = row.get("divisa").trim().toUpperCase() || "EUR";
+      // Trade rows carry gross amounts (fees are separate "Commissioni" rows)
+      // and no unit price, so price is derived from amount and quantity.
+      // Non-EUR trades store the native amount in "Importo Divisa".
+      const amount = parseNumberStrict(
+        currency === "EUR"
+          ? row.get("importo_euro")
+          : row.get("importo_divisa"),
+      );
+
+      if (!name) {
+        errors.push(`Row ${rowNumber}: Missing descrizione`);
+        continue;
+      }
+
+      if (!dateKey) {
+        errors.push(`Row ${rowNumber}: Invalid date "${dateRaw}"`);
+        continue;
+      }
+
+      if (!Number.isFinite(quantity) || quantity <= 0) {
+        errors.push(
+          `Row ${rowNumber}: Invalid quantity "${row.get(quantityHeader)}"`,
+        );
+        continue;
+      }
+
+      if (!Number.isFinite(amount) || Math.abs(amount) < ZERO_EPSILON) {
+        errors.push(
+          `Row ${rowNumber}: Invalid amount for currency ${currency}`,
+        );
+        continue;
+      }
+
+      const type = SELL_TYPES.has(rawType) ? "sell" : "buy";
+      const unitValue = Math.abs(amount) / quantity;
+      const positionKey = buildPositionKey(name, isin);
+      const existingPosition = positionsByKey.get(positionKey);
+      const signedQuantity = type === "sell" ? -quantity : quantity;
+
+      if (existingPosition) {
+        existingPosition.endingQuantity = normalizeEndingQuantity(
+          existingPosition.endingQuantity + signedQuantity,
+        );
+        if (dateKey < existingPosition.earliestTradeDate) {
+          existingPosition.earliestTradeDate = dateKey;
+          existingPosition.firstUnitValue = unitValue;
+        }
+      } else {
+        positionsByKey.set(positionKey, {
+          positionKey,
+          name,
+          // The export carries no asset-class column; users can recategorize.
+          category_id: "other",
+          currency,
+          brokerSymbol: isin || null,
+          earliestTradeDate: dateKey,
+          firstUnitValue: unitValue,
+          endingQuantity: normalizeEndingQuantity(signedQuantity),
+        });
+      }
+
+      records.push({
+        source: SOURCE,
+        positionKey,
+        positionName: name,
+        type,
+        date: dateKey,
+        quantity,
+        unit_value: unitValue,
+        description: null,
+        external_transaction_id: buildTransactionId([
+          dateKey,
+          isin || normalizeKeyPart(name),
+          type,
+          quantity,
+          amount,
+        ]),
+        sourceRowNumber: rowNumber,
+      });
+    }
+
+    assignFileOrderExecutedAt(records);
+
+    if (ignoredFeeRowCount > 0) {
+      warnings.push(
+        `Ignored ${ignoredFeeRowCount} Directa commission row(s); Foliofox records store quantity and unit price only in v1.`,
+      );
+    }
+
+    if (ignoredOtherRowCount > 0) {
+      warnings.push(
+        `Ignored ${ignoredOtherRowCount} non-trade Directa row(s). V1 imports only Acquisto and Vendita rows.`,
+      );
+    }
+
+    return {
+      success: errors.length === 0,
+      source: SOURCE,
+      positions: Array.from(positionsByKey.values()),
+      records,
+      ignoredRowCount,
+      duplicateTransactionIdCount: 0,
+      warnings: warnings.length > 0 ? warnings : undefined,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  },
+};

--- a/lib/import/broker-transactions/adapters/scalable-capital.ts
+++ b/lib/import/broker-transactions/adapters/scalable-capital.ts
@@ -1,7 +1,10 @@
 import { formatUTCDateKey, parseUTCDateKey } from "@/lib/date/date-utils";
-import { mapCategory } from "@/lib/import/positions/category-mapper";
 import { parseNumberStrict } from "@/lib/import/shared/number-parser";
 
+import {
+  assignFileOrderExecutedAt,
+  createSyntheticTransactionIdFactory,
+} from "../adapter-utils";
 import { normalizeBrokerHeader, parseBrokerTransactionCSVTable } from "../csv";
 
 import type {
@@ -11,30 +14,31 @@ import type {
   BrokerTransactionRecordDraft,
 } from "../types";
 
-const SOURCE = "trade_republic";
-const DISPLAY_NAME = "Trade Republic";
+const SOURCE = "scalable_capital";
+const DISPLAY_NAME = "Scalable Capital";
 const REQUIRED_HEADERS = [
-  "datetime",
   "date",
-  "category",
+  "description",
   "type",
-  "asset_class",
-  "name",
-  "symbol",
+  "isin",
   "shares",
   "price",
+  "amount",
+  "fee",
+  "tax",
   "currency",
-  "transaction_id",
 ];
+// Savings plan executions are scheduled buys of the same instrument.
+const BUY_TYPES = new Set(["buy", "savings plan"]);
+const SELL_TYPES = new Set(["sell"]);
 const ZERO_EPSILON = 1e-9;
 
 function normalizeKeyPart(value: string): string {
   return value.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
-function buildPositionKey(name: string, brokerSymbol: string): string {
-  const symbolPart = brokerSymbol.trim() || normalizeKeyPart(name);
-  return `${SOURCE}:${normalizeKeyPart(symbolPart)}:${normalizeKeyPart(name)}`;
+function buildPositionKey(name: string, isin: string): string {
+  return `${SOURCE}:${normalizeKeyPart(isin)}:${normalizeKeyPart(name)}`;
 }
 
 function normalizeEndingQuantity(quantity: number): number {
@@ -46,23 +50,23 @@ function hasNonZeroAmount(rawValue: string): boolean {
   return Number.isFinite(parsed) && parsed !== 0;
 }
 
-function hasRequiredTradeRepublicHeaders(headers: string[]): boolean {
+function hasRequiredScalableCapitalHeaders(headers: string[]): boolean {
   const normalizedHeaders = new Set(headers.map(normalizeBrokerHeader));
   return REQUIRED_HEADERS.every((header) => normalizedHeaders.has(header));
 }
 
-function detectTradeRepublicCSV(csvContent: string): boolean {
+function detectScalableCapitalCSV(csvContent: string): boolean {
   const parsedTable = parseBrokerTransactionCSVTable(csvContent);
   return (
     parsedTable.success &&
-    hasRequiredTradeRepublicHeaders(parsedTable.table.headers)
+    hasRequiredScalableCapitalHeaders(parsedTable.table.headers)
   );
 }
 
-export const tradeRepublicAdapter: BrokerTransactionAdapter = {
+export const scalableCapitalAdapter: BrokerTransactionAdapter = {
   source: SOURCE,
   displayName: DISPLAY_NAME,
-  detect: detectTradeRepublicCSV,
+  detect: detectScalableCapitalCSV,
   async parse(csvContent: string): Promise<BrokerTransactionImportResult> {
     const parsedTable = parseBrokerTransactionCSVTable(csvContent);
     if (!parsedTable.success) {
@@ -77,7 +81,7 @@ export const tradeRepublicAdapter: BrokerTransactionAdapter = {
       };
     }
 
-    if (!hasRequiredTradeRepublicHeaders(parsedTable.table.headers)) {
+    if (!hasRequiredScalableCapitalHeaders(parsedTable.table.headers)) {
       return {
         success: false,
         source: SOURCE,
@@ -85,7 +89,7 @@ export const tradeRepublicAdapter: BrokerTransactionAdapter = {
         records: [],
         ignoredRowCount: 0,
         duplicateTransactionIdCount: 0,
-        errors: ["CSV file does not match the Trade Republic export format"],
+        errors: ["CSV file does not match the Scalable Capital export format"],
       };
     }
 
@@ -93,59 +97,44 @@ export const tradeRepublicAdapter: BrokerTransactionAdapter = {
     const records: BrokerTransactionRecordDraft[] = [];
     const errors: string[] = [];
     const warnings: string[] = [];
-    const seenTransactionIds = new Set<string>();
+    // Scalable Capital exports have no per-row transaction ID, so IDs are
+    // derived from normalized row content for idempotent re-uploads.
+    const buildTransactionId = createSyntheticTransactionIdFactory();
     let ignoredRowCount = 0;
-    let ignoredNonTradingRowCount = 0;
-    let duplicateTransactionIdCount = 0;
+    let ignoredNonTradeRowCount = 0;
     let importedRowsWithFeesOrTaxes = 0;
 
     for (const row of parsedTable.table.rows) {
-      const category = row.get("category").trim().toUpperCase();
-      const rawType = row.get("type").trim().toUpperCase();
+      const rawType = row.get("type").trim().toLowerCase();
 
-      // Trade Republic exports cash, dividends, interest, transfers, and card
-      // activity in the same file. V1 imports only position-changing trades.
-      if (category !== "TRADING" || !["BUY", "SELL"].includes(rawType)) {
-        ignoredNonTradingRowCount++;
+      // Scalable Capital exports deposits, withdrawals, dividends, interest,
+      // and fees in the same file. V1 imports only position-changing trades.
+      if (!BUY_TYPES.has(rawType) && !SELL_TYPES.has(rawType)) {
+        ignoredNonTradeRowCount++;
         ignoredRowCount++;
         continue;
       }
 
-      const externalTransactionId = row.get("transaction_id").trim();
-      if (!externalTransactionId) {
-        errors.push(`Row ${row.rowNumber}: Missing transaction_id`);
-        continue;
-      }
-
-      if (seenTransactionIds.has(externalTransactionId)) {
-        duplicateTransactionIdCount++;
-        ignoredRowCount++;
-        continue;
-      }
-      seenTransactionIds.add(externalTransactionId);
-
-      const name = row.get("name").trim();
-      const brokerSymbol = row.get("symbol").trim();
-      const datetimeRaw = row.get("datetime").trim();
+      const name = row.get("description").trim();
+      const isin = row.get("isin").trim().toUpperCase();
       const dateRaw = row.get("date").trim();
-      const parsedDatetime = new Date(datetimeRaw);
       const parsedDate = parseUTCDateKey(dateRaw);
       const quantity = Math.abs(parseNumberStrict(row.get("shares")));
       const unitValue = parseNumberStrict(row.get("price"));
       const currency = row.get("currency").trim().toUpperCase();
 
       if (!name) {
-        errors.push(`Row ${row.rowNumber}: Missing name`);
+        errors.push(`Row ${row.rowNumber}: Missing description`);
+        continue;
+      }
+
+      if (!isin) {
+        errors.push(`Row ${row.rowNumber}: Missing isin`);
         continue;
       }
 
       if (Number.isNaN(parsedDate.getTime())) {
         errors.push(`Row ${row.rowNumber}: Invalid date "${dateRaw}"`);
-        continue;
-      }
-
-      if (Number.isNaN(parsedDatetime.getTime())) {
-        errors.push(`Row ${row.rowNumber}: Invalid datetime "${datetimeRaw}"`);
         continue;
       }
 
@@ -175,10 +164,11 @@ export const tradeRepublicAdapter: BrokerTransactionAdapter = {
         importedRowsWithFeesOrTaxes++;
       }
 
+      const type = SELL_TYPES.has(rawType) ? "sell" : "buy";
       const normalizedDate = formatUTCDateKey(parsedDate);
-      const positionKey = buildPositionKey(name, brokerSymbol);
+      const positionKey = buildPositionKey(name, isin);
       const existingPosition = positionsByKey.get(positionKey);
-      const signedQuantity = rawType === "SELL" ? -quantity : quantity;
+      const signedQuantity = type === "sell" ? -quantity : quantity;
 
       if (existingPosition) {
         existingPosition.endingQuantity = normalizeEndingQuantity(
@@ -192,9 +182,10 @@ export const tradeRepublicAdapter: BrokerTransactionAdapter = {
         positionsByKey.set(positionKey, {
           positionKey,
           name,
-          category_id: mapCategory(row.get("asset_class")),
+          // The export carries no asset-class column; users can recategorize.
+          category_id: "other",
           currency,
-          brokerSymbol: brokerSymbol || null,
+          brokerSymbol: isin,
           earliestTradeDate: normalizedDate,
           firstUnitValue: unitValue,
           endingQuantity: normalizeEndingQuantity(signedQuantity),
@@ -205,26 +196,27 @@ export const tradeRepublicAdapter: BrokerTransactionAdapter = {
         source: SOURCE,
         positionKey,
         positionName: name,
-        type: rawType === "SELL" ? "sell" : "buy",
+        type,
         date: normalizedDate,
         quantity,
         unit_value: unitValue,
-        description: row.get("description").trim() || null,
-        external_transaction_id: externalTransactionId,
+        description: null,
+        external_transaction_id: buildTransactionId([
+          normalizedDate,
+          isin,
+          type,
+          quantity,
+          unitValue,
+        ]),
         sourceRowNumber: row.rowNumber,
-        executedAt: parsedDatetime.toISOString(),
       });
     }
 
-    if (ignoredNonTradingRowCount > 0) {
-      warnings.push(
-        `Ignored ${ignoredNonTradingRowCount} non-trading Trade Republic row(s). V1 imports only BUY and SELL trading rows; cash movements, dividends, interest, fees, and taxes are not imported.`,
-      );
-    }
+    assignFileOrderExecutedAt(records);
 
-    if (duplicateTransactionIdCount > 0) {
+    if (ignoredNonTradeRowCount > 0) {
       warnings.push(
-        `Skipped ${duplicateTransactionIdCount} duplicate transaction_id row(s) in this file.`,
+        `Ignored ${ignoredNonTradeRowCount} non-trade Scalable Capital row(s). V1 imports only Buy, Sell, and Savings plan rows; deposits, withdrawals, dividends, interest, fees, and taxes are not imported.`,
       );
     }
 
@@ -240,7 +232,7 @@ export const tradeRepublicAdapter: BrokerTransactionAdapter = {
       positions: Array.from(positionsByKey.values()),
       records,
       ignoredRowCount,
-      duplicateTransactionIdCount,
+      duplicateTransactionIdCount: 0,
       warnings: warnings.length > 0 ? warnings : undefined,
       errors: errors.length > 0 ? errors : undefined,
     };

--- a/lib/import/broker-transactions/adapters/scalable-capital.ts
+++ b/lib/import/broker-transactions/adapters/scalable-capital.ts
@@ -100,8 +100,8 @@ export const scalableCapitalAdapter: BrokerTransactionAdapter = {
     // Scalable Capital exports have no per-row transaction ID, so IDs are
     // derived from normalized row content for idempotent re-uploads.
     const buildTransactionId = createSyntheticTransactionIdFactory();
+    // Every ignored row is a non-trade row for this adapter.
     let ignoredRowCount = 0;
-    let ignoredNonTradeRowCount = 0;
     let importedRowsWithFeesOrTaxes = 0;
 
     for (const row of parsedTable.table.rows) {
@@ -110,7 +110,6 @@ export const scalableCapitalAdapter: BrokerTransactionAdapter = {
       // Scalable Capital exports deposits, withdrawals, dividends, interest,
       // and fees in the same file. V1 imports only position-changing trades.
       if (!BUY_TYPES.has(rawType) && !SELL_TYPES.has(rawType)) {
-        ignoredNonTradeRowCount++;
         ignoredRowCount++;
         continue;
       }
@@ -214,9 +213,9 @@ export const scalableCapitalAdapter: BrokerTransactionAdapter = {
 
     assignFileOrderExecutedAt(records);
 
-    if (ignoredNonTradeRowCount > 0) {
+    if (ignoredRowCount > 0) {
       warnings.push(
-        `Ignored ${ignoredNonTradeRowCount} non-trade Scalable Capital row(s). V1 imports only Buy, Sell, and Savings plan rows; deposits, withdrawals, dividends, interest, fees, and taxes are not imported.`,
+        `Ignored ${ignoredRowCount} non-trade Scalable Capital row(s). V1 imports only Buy, Sell, and Savings plan rows; deposits, withdrawals, dividends, interest, fees, and taxes are not imported.`,
       );
     }
 

--- a/lib/import/broker-transactions/adapters/scalable-capital.ts
+++ b/lib/import/broker-transactions/adapters/scalable-capital.ts
@@ -170,6 +170,14 @@ export const scalableCapitalAdapter: BrokerTransactionAdapter = {
       const signedQuantity = type === "sell" ? -quantity : quantity;
 
       if (existingPosition) {
+        // Records carry no per-row currency, so one instrument trading in two
+        // currencies within a file cannot be priced safely.
+        if (existingPosition.currency !== currency) {
+          errors.push(
+            `Row ${row.rowNumber}: "${name}" mixes trade currencies (${existingPosition.currency} and ${currency}), which is not supported yet`,
+          );
+          continue;
+        }
         existingPosition.endingQuantity = normalizeEndingQuantity(
           existingPosition.endingQuantity + signedQuantity,
         );

--- a/lib/import/broker-transactions/directa.test.ts
+++ b/lib/import/broker-transactions/directa.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  detectBrokerTransactionAdapter,
+  parseBrokerTransactionsCSV,
+} from "./registry";
+
+const DIRECTA_PREAMBLE = `Conto : 12345 MARIO ROSSI;;;;;;;;;;;
+Data estrazione : 15-7-2026 11:53:37;;;;;;;;;;;
+;;;;;;;;;;;
+Compravendite ordinati per Data Operazione;;;;;;;;;;;
+Dal : 01-01-2020;;;;;;;;;;;
+al : 15-07-2026;;;;;;;;;;;
+;;;;;;;;;;;
+Il file include i primi 3000 movimenti;;;;;;;;;;;
+;;;;;;;;;;;`;
+const DIRECTA_HEADER =
+  "Data operazione;Data valuta;Tipo operazione;Ticker;Isin;Protocollo;Descrizione;Quantità;Importo euro;Importo Divisa;Divisa;Riferimento ordine";
+
+function buildDirectaCSV(rows: string[]): string {
+  return [DIRECTA_PREAMBLE, DIRECTA_HEADER, ...rows].join("\n");
+}
+
+describe("Directa broker transaction adapter", () => {
+  it("detects Directa exports despite the metadata preamble", () => {
+    const adapter = detectBrokerTransactionAdapter(
+      buildDirectaCSV([
+        "15/01/2026;19/01/2026;Acquisto;VWCE;IE0000000001;;World ETF;2;-300,52;0;EUR;X123",
+      ]),
+    );
+
+    expect(adapter?.source).toBe("directa");
+  });
+
+  it("normalizes buys and sells with dd/mm/yyyy dates and derived unit prices", async () => {
+    const csv = buildDirectaCSV([
+      "15/01/2026;19/01/2026;Vendita;VWCE;IE0000000001;;World ETF;2;220,00;0;EUR;X124",
+      "11/10/2022;13/10/2022;Acquisto;VWCE;IE0000000001;;World ETF;11;-997,15;0;EUR;X123",
+    ]);
+
+    const result = await parseBrokerTransactionsCSV(csv);
+
+    expect(result.success).toBe(true);
+    expect(result.source).toBe("directa");
+    expect(result.positions).toHaveLength(1);
+    expect(result.positions[0]).toMatchObject({
+      name: "World ETF",
+      category_id: "other",
+      currency: "EUR",
+      brokerSymbol: "IE0000000001",
+      earliestTradeDate: "2022-10-11",
+      firstUnitValue: 997.15 / 11,
+      endingQuantity: 9,
+    });
+    expect(result.records).toEqual([
+      expect.objectContaining({
+        type: "sell",
+        date: "2026-01-15",
+        quantity: 2,
+        unit_value: 110,
+      }),
+      expect.objectContaining({
+        type: "buy",
+        date: "2022-10-11",
+        quantity: 11,
+        unit_value: 997.15 / 11,
+      }),
+    ]);
+  });
+
+  it("ignores commission and other non-trade rows with warnings", async () => {
+    const csv = buildDirectaCSV([
+      "15/01/2026;19/01/2026;Acquisto;VWCE;IE0000000001;;World ETF;2;-300,52;0;EUR;X123",
+      "15/01/2026;19/01/2026;Commissioni;VWCE;IE0000000001;;World ETF;0;-1,5;0;EUR;X123",
+      "10/01/2026;12/01/2026;Dividendi;VWCE;IE0000000001;;World ETF;0;12,00;0;EUR;X122",
+    ]);
+
+    const result = await parseBrokerTransactionsCSV(csv);
+
+    expect(result.success).toBe(true);
+    expect(result.records).toHaveLength(1);
+    expect(result.ignoredRowCount).toBe(2);
+    expect(
+      result.warnings?.some((warning) => warning.includes("commission")),
+    ).toBe(true);
+    expect(
+      result.warnings?.some((warning) => warning.includes("non-trade")),
+    ).toBe(true);
+  });
+
+  it("uses the native currency amount for non-EUR trades", async () => {
+    const csv = buildDirectaCSV([
+      "21/01/2021;25/01/2021;Acquisto;.ACME;US0000000001;;ACME INC;12;-185,94;-226,17;USD;X123",
+    ]);
+
+    const result = await parseBrokerTransactionsCSV(csv);
+
+    expect(result.success).toBe(true);
+    expect(result.positions[0]).toMatchObject({ currency: "USD" });
+    expect(result.records[0]).toMatchObject({
+      quantity: 12,
+      unit_value: 226.17 / 12,
+    });
+  });
+
+  it("keeps synthetic IDs stable across differently mangled order references", async () => {
+    // Two fills of the same order are identical rows; an Excel round-trip can
+    // mangle the order reference, which must not change the record IDs.
+    const exportA = buildDirectaCSV([
+      "22/06/2026;24/06/2026;Acquisto;WWRD;XS0000000001;;World ETF;100;-2500,5;0;EUR;17300000000000",
+      "22/06/2026;24/06/2026;Acquisto;WWRD;XS0000000001;;World ETF;100;-2500,5;0;EUR;17300000000000",
+    ]);
+    const exportB = buildDirectaCSV([
+      "22/06/2026;24/06/2026;Acquisto;WWRD;XS0000000001;;World ETF;100;-2500,50;0;EUR;1,73E+13",
+      "22/06/2026;24/06/2026;Acquisto;WWRD;XS0000000001;;World ETF;100;-2500,50;0;EUR;1,73E+13",
+    ]);
+
+    const resultA = await parseBrokerTransactionsCSV(exportA);
+    const resultB = await parseBrokerTransactionsCSV(exportB);
+
+    const idsA = resultA.records.map(
+      (record) => record.external_transaction_id,
+    );
+    expect(new Set(idsA).size).toBe(2);
+    expect(
+      resultB.records.map((record) => record.external_transaction_id),
+    ).toEqual(idsA);
+  });
+
+  it("orders same-day trades chronologically in newest-first exports", async () => {
+    const csv = buildDirectaCSV([
+      "15/01/2026;19/01/2026;Vendita;VWCE;IE0000000001;;World ETF;2;220,00;0;EUR;X125",
+      "15/01/2026;19/01/2026;Acquisto;VWCE;IE0000000001;;World ETF;2;-210,00;0;EUR;X124",
+      "10/01/2026;12/01/2026;Acquisto;VWCE;IE0000000001;;World ETF;1;-100,00;0;EUR;X123",
+    ]);
+
+    const result = await parseBrokerTransactionsCSV(csv);
+    const [sell, buy] = result.records.filter(
+      (record) => record.date === "2026-01-15",
+    );
+
+    expect(sell.executedAt! > buy.executedAt!).toBe(true);
+  });
+});

--- a/lib/import/broker-transactions/directa.test.ts
+++ b/lib/import/broker-transactions/directa.test.ts
@@ -127,6 +127,20 @@ describe("Directa broker transaction adapter", () => {
     ).toEqual(idsA);
   });
 
+  it("rejects rows that mix trade currencies for one instrument", async () => {
+    const csv = buildDirectaCSV([
+      "16/01/2026;20/01/2026;Vendita;.ACME;US0000000001;;ACME INC;1;50,00;60,00;USD;X2",
+      "15/01/2026;19/01/2026;Acquisto;ACME;US0000000001;;ACME INC;2;-100,00;0;EUR;X1",
+    ]);
+
+    const result = await parseBrokerTransactionsCSV(csv);
+
+    expect(result.success).toBe(false);
+    expect(
+      result.errors?.some((error) => error.includes("mixes trade currencies")),
+    ).toBe(true);
+  });
+
   it("orders same-day trades chronologically in newest-first exports", async () => {
     const csv = buildDirectaCSV([
       "15/01/2026;19/01/2026;Vendita;VWCE;IE0000000001;;World ETF;2;220,00;0;EUR;X125",

--- a/lib/import/broker-transactions/registry.ts
+++ b/lib/import/broker-transactions/registry.ts
@@ -1,4 +1,5 @@
-import { parseBrokerTransactionCSVTable } from "./csv";
+import { directaAdapter } from "./adapters/directa";
+import { scalableCapitalAdapter } from "./adapters/scalable-capital";
 import { tradeRepublicAdapter } from "./adapters/trade-republic";
 
 import type {
@@ -8,18 +9,27 @@ import type {
 
 const BROKER_TRANSACTION_ADAPTERS: BrokerTransactionAdapter[] = [
   tradeRepublicAdapter,
+  scalableCapitalAdapter,
+  directaAdapter,
 ];
 
 export function detectBrokerTransactionAdapter(
   csvContent: string,
 ): BrokerTransactionAdapter | null {
-  const parsedTable = parseBrokerTransactionCSVTable(csvContent);
-  if (!parsedTable.success) return null;
-
   return (
-    BROKER_TRANSACTION_ADAPTERS.find((adapter) =>
-      adapter.detect(parsedTable.table.headers),
-    ) ?? null
+    BROKER_TRANSACTION_ADAPTERS.find((adapter) => adapter.detect(csvContent)) ??
+    null
+  );
+}
+
+export function listSupportedBrokerDisplayNames(): string[] {
+  return BROKER_TRANSACTION_ADAPTERS.map((adapter) => adapter.displayName);
+}
+
+export function getBrokerDisplayName(source: string): string | null {
+  return (
+    BROKER_TRANSACTION_ADAPTERS.find((adapter) => adapter.source === source)
+      ?.displayName ?? null
   );
 }
 

--- a/lib/import/broker-transactions/scalable-capital.test.ts
+++ b/lib/import/broker-transactions/scalable-capital.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  detectBrokerTransactionAdapter,
+  parseBrokerTransactionsCSV,
+} from "./registry";
+
+const SCALABLE_HEADER =
+  "date;description;type;isin;shares;price;amount;fee;tax;currency";
+
+describe("Scalable Capital broker transaction adapter", () => {
+  it("detects Scalable Capital transaction exports by header shape", () => {
+    const adapter = detectBrokerTransactionAdapter(`${SCALABLE_HEADER}
+2026-05-05;World ETF;Buy;LU0000000001;2;11,198;-22,396;0,99;0,00;EUR`);
+
+    expect(adapter?.source).toBe("scalable_capital");
+  });
+
+  it("normalizes buy, sell, and savings plan rows with EU number formats", async () => {
+    const csv = `${SCALABLE_HEADER}
+2026-05-13;World ETF;Savings plan;LU0000000001;3,140309;159,22;-499,99999898;0,00;0,00;EUR
+2026-05-05;World ETF;Buy;LU0000000001;2;11,198;-22,396;0,99;0,00;EUR
+2026-05-04;Oil ETC;Sell;JE0000000001;1;77,995;77,995;0,99;0,00;EUR`;
+
+    const result = await parseBrokerTransactionsCSV(csv);
+
+    expect(result.success).toBe(true);
+    expect(result.source).toBe("scalable_capital");
+    expect(result.positions).toHaveLength(2);
+    expect(result.positions[0]).toMatchObject({
+      name: "World ETF",
+      category_id: "other",
+      currency: "EUR",
+      brokerSymbol: "LU0000000001",
+      earliestTradeDate: "2026-05-05",
+      firstUnitValue: 11.198,
+      endingQuantity: 5.140309,
+    });
+    expect(result.records).toEqual([
+      expect.objectContaining({
+        type: "buy",
+        date: "2026-05-13",
+        quantity: 3.140309,
+        unit_value: 159.22,
+      }),
+      expect.objectContaining({
+        type: "buy",
+        date: "2026-05-05",
+        quantity: 2,
+        unit_value: 11.198,
+      }),
+      expect.objectContaining({
+        type: "sell",
+        date: "2026-05-04",
+        quantity: 1,
+        unit_value: 77.995,
+      }),
+    ]);
+    expect(
+      result.warnings?.some((warning) => warning.includes("fee/tax")),
+    ).toBe(true);
+  });
+
+  it("ignores deposits and other non-trade rows with a warning", async () => {
+    const csv = `${SCALABLE_HEADER}
+2026-05-11;Savings plan deposit;Deposit;;;;500,00;0,00;;EUR
+2026-05-05;World ETF;Buy;LU0000000001;2;11,198;-22,396;0,00;0,00;EUR`;
+
+    const result = await parseBrokerTransactionsCSV(csv);
+
+    expect(result.success).toBe(true);
+    expect(result.ignoredRowCount).toBe(1);
+    expect(result.records).toHaveLength(1);
+    expect(
+      result.warnings?.some((warning) => warning.includes("non-trade")),
+    ).toBe(true);
+  });
+
+  it("builds deterministic synthetic transaction IDs across re-uploads", async () => {
+    const csv = `${SCALABLE_HEADER}
+2026-05-05;World ETF;Buy;LU0000000001;2;11,198;-22,396;0,00;0,00;EUR
+2026-05-05;World ETF;Buy;LU0000000001;2;11,198;-22,396;0,00;0,00;EUR`;
+
+    const first = await parseBrokerTransactionsCSV(csv);
+    const second = await parseBrokerTransactionsCSV(csv);
+
+    const firstIds = first.records.map(
+      (record) => record.external_transaction_id,
+    );
+    // Identical fills stay distinct via the occurrence suffix, while the same
+    // file parsed again produces the same IDs so re-uploads skip them.
+    expect(new Set(firstIds).size).toBe(2);
+    expect(firstIds[0]).toBe("2026-05-05|LU0000000001|buy|2|11.198#1");
+    expect(firstIds[1]).toBe("2026-05-05|LU0000000001|buy|2|11.198#2");
+    expect(
+      second.records.map((record) => record.external_transaction_id),
+    ).toEqual(firstIds);
+  });
+
+  it("orders same-day trades chronologically in newest-first exports", async () => {
+    const csv = `${SCALABLE_HEADER}
+2026-05-05;World ETF;Sell;LU0000000001;2;12,00;24,00;0,00;0,00;EUR
+2026-05-05;World ETF;Buy;LU0000000001;2;11,198;-22,396;0,00;0,00;EUR
+2026-05-04;World ETF;Buy;LU0000000001;1;11,00;-11,00;0,00;0,00;EUR`;
+
+    const result = await parseBrokerTransactionsCSV(csv);
+    const [sell, buy] = result.records.filter(
+      (record) => record.date === "2026-05-05",
+    );
+
+    // The sell appears first in the file but happened after the buy.
+    expect(sell.executedAt! > buy.executedAt!).toBe(true);
+  });
+});

--- a/lib/import/broker-transactions/scalable-capital.test.ts
+++ b/lib/import/broker-transactions/scalable-capital.test.ts
@@ -97,6 +97,19 @@ describe("Scalable Capital broker transaction adapter", () => {
     ).toEqual(firstIds);
   });
 
+  it("rejects rows that mix trade currencies for one instrument", async () => {
+    const csv = `${SCALABLE_HEADER}
+2026-05-05;World ETF;Buy;LU0000000001;2;11,00;-22,00;0,00;0,00;EUR
+2026-05-04;World ETF;Buy;LU0000000001;1;12,00;-12,00;0,00;0,00;USD`;
+
+    const result = await parseBrokerTransactionsCSV(csv);
+
+    expect(result.success).toBe(false);
+    expect(
+      result.errors?.some((error) => error.includes("mixes trade currencies")),
+    ).toBe(true);
+  });
+
   it("orders same-day trades chronologically in newest-first exports", async () => {
     const csv = `${SCALABLE_HEADER}
 2026-05-05;World ETF;Sell;LU0000000001;2;12,00;24,00;0,00;0,00;EUR

--- a/lib/import/broker-transactions/types.ts
+++ b/lib/import/broker-transactions/types.ts
@@ -56,6 +56,8 @@ export interface BrokerTransactionAdapter {
   // Persisted to portfolio_records.import_source for idempotency.
   source: string;
   displayName: string;
-  detect: (headers: string[]) => boolean;
+  // Receives raw file content so each adapter fully owns its detection,
+  // including exports with metadata preamble lines before the header row.
+  detect: (csvContent: string) => boolean;
   parse: (csvContent: string) => Promise<BrokerTransactionImportResult>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,13 +88,13 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.19.tgz",
-      "integrity": "sha512-pQ3UPO0tyLUuW751jdgWhvHmXmjvAFpyiTeZF6eSVHMYhH/dSH4FtSKGT2nOnvvpaRpU8ygsLV4ng2Mz0lcU/A==",
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.21.tgz",
+      "integrity": "sha512-GafyeyHFDKJjdtbyhCQ0aC2FORdyE56IxK45EZ1JLO1iVdg8XqEU3bwnRzI0+5S1XHV7W2qQsxkZnGYPbsFiXA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "4.0.3",
-        "@ai-sdk/provider-utils": "5.0.9",
+        "@ai-sdk/provider-utils": "5.0.10",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
@@ -105,13 +105,13 @@
       }
     },
     "node_modules/@ai-sdk/mcp": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.12.tgz",
-      "integrity": "sha512-fJkjzA9m+69sCUTaEhp7kRQQl9MkGbau9gndQweKLXsEtlzBGs1d7R2kbgQ/GVyrkoWg0EAWPUkawbFWWjjqpg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.14.tgz",
+      "integrity": "sha512-Vf2THTWylnOiPUZgPEzTcbin+6pIBKMdJnDNAMHD0u+upNoO5747HMMFUJJnNNjk8eroAPomaVmF0w8gadA4WA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "4.0.3",
-        "@ai-sdk/provider-utils": "5.0.9",
+        "@ai-sdk/provider-utils": "5.0.10",
         "pkce-challenge": "^5.0.1"
       },
       "engines": {
@@ -122,13 +122,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.13.tgz",
-      "integrity": "sha512-7I2sx9NyT2XJ8YrpBr0twwASv6mgpI9Gu7mNxtevmdJ0n8UxUKtcG1NHNjaOEzN5pKzNAv3XcBOVom9DwJ2CpA==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.15.tgz",
+      "integrity": "sha512-JpTLQp5RUbRcs5nOyPEu5NRdxZLUnD/uCyT3qzy26D+iunCeL7KJV58ER9kwisAKnTjWravfNblaQNiWr20M9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "4.0.3",
-        "@ai-sdk/provider-utils": "5.0.9"
+        "@ai-sdk/provider-utils": "5.0.10"
       },
       "engines": {
         "node": ">=22"
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.9.tgz",
-      "integrity": "sha512-BohlmQ62x+iIOawYCS2z5JzokMq5kZSoVhJawH41mlMdkb01xqhIMG8L0NAByneUFLpdUlSjJjF/bel5j3cGZA==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.10.tgz",
+      "integrity": "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "4.0.3",
@@ -168,15 +168,15 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.27.tgz",
-      "integrity": "sha512-1c7tOsy7kxs7ukwnuLXwsKYLQBipdrfCvNViLxCxPSG+e3w8xH7WN3AmwVPjRZvFBQIZGMSCfsCNvZSZCPk2UA==",
+      "version": "4.0.32",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.32.tgz",
+      "integrity": "sha512-H1tu1C5XoY1fh14Q4ABS1ljPx+H/y20MqJrUhATW5jjdAqOyyAy0rFl2qj5BC9uhFMtM+NkxEUOEPB5qeQLDQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/mcp": "2.0.12",
+        "@ai-sdk/mcp": "2.0.14",
         "@ai-sdk/provider": "4.0.3",
-        "@ai-sdk/provider-utils": "5.0.9",
-        "ai": "7.0.26",
+        "@ai-sdk/provider-utils": "5.0.10",
+        "ai": "7.0.29",
         "swr": "^2.4.1",
         "throttleit": "2.1.0"
       },
@@ -2984,12 +2984,12 @@
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.40.2",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.40.2.tgz",
-      "integrity": "sha512-H12j7O9iHGvpK9t2ko8W4pvfbV1pBDxrsWC1LA6yp2RhzwvC4T3sWhu+AekDQJSRSrJEWlB0t/Ueq9QhPSq7FQ==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.42.1.tgz",
+      "integrity": "sha512-cZojBmvf92gZAn0MGf/J2S+3t2sZqb9E2/6mjY4jJsImwz7PuYqdNj870Wx2iwwlf++wfhRuH4K4bpDy9GIoCA==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "^1.393.0"
+        "@posthog/types": "^1.395.0"
       }
     },
     "node_modules/@posthog/react": {
@@ -3009,9 +3009,9 @@
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.393.0",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.393.0.tgz",
-      "integrity": "sha512-vzWeEJZ7ERQhFRoQYaP5jzN1JvIu46UJyHXsuv+dTGW2r3sMgREOhNxXLZjmFHwZ8/FOHQoyqqQmXTCXZSfMSg==",
+      "version": "1.395.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.395.0.tgz",
+      "integrity": "sha512-Ty0gbVc6d9ku9H3caF54PmEfu4PHUGpJKTriMyDb4rjCTsEYOOjD4r6Fw/UMYSSWg8Ls3KnCtTow8LL6ciqNDg==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
@@ -4541,9 +4541,9 @@
       }
     },
     "node_modules/@react-email/ui": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@react-email/ui/-/ui-6.8.1.tgz",
-      "integrity": "sha512-HnHsUBqhFoWAXZkhGqot88dBxoprUUqYF5XSei/OOI/PsMCOl6b39+HCGEQN2qzTZq335qs2s14pnpVgSCJ8nA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@react-email/ui/-/ui-6.9.0.tgz",
+      "integrity": "sha512-VjIT3FpWHk4Q+t+z5IZcS5KtcXfjTpJxXZ5A1I0LZhgV1pn2IKXqc4Mvs4vWXujgCTS25NVy55QX8zztxitzhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5444,9 +5444,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.110.4",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.4.tgz",
-      "integrity": "sha512-nD+gsHRX7/qCCKzpX8Lch/NUi0rmg4YereGTFzUT0BkPJ0ObDLkhCfjfiloRNLky1oHkb+QLA45Vx2zAsQ6iIQ==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.6.tgz",
+      "integrity": "sha512-20v99wV4dodllbDOsD8AUVkQ7Ie+vwcgPeORY9YlC9YyJSmVgWff9gRTdgmyfE6GJHoSMJuQ4HZokSLHA/7YUg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -5580,9 +5580,9 @@
       ]
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.110.4",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.4.tgz",
-      "integrity": "sha512-661Bg5VeEDv6twzQhXzoBpPV4xswuwGGDzmBkpa1wmpwu5/veHqT2lURNxCowCiUOWIkj8fJ9LLjq0sgwBIA4A==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.6.tgz",
+      "integrity": "sha512-Ih/I766vc579WfNzXSv1ERssCHKzaPj9rpST/j9wsMuUv+AfmRteKrJn3sVmrJIwQU5qJya2+aWTlvhf4WoMsg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -5598,9 +5598,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.110.4",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.4.tgz",
-      "integrity": "sha512-TVTPrB8Ee/0dqA6B1fieMnCS32TYi5IRgIFuW5jL5DWGtw/y9XIojVkgLROdm8mhfpkiwt51lEtKYb3jl5cx1w==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.6.tgz",
+      "integrity": "sha512-kDNKncLtYBI/QT8HuVGSui/F3KrC3iWy7KM5M3EvWbEujf1cL+fdwMr2eeA8PEZUIPBeNbDxRzdFZo5t86iqUQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -5610,9 +5610,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.110.4",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.4.tgz",
-      "integrity": "sha512-nPtV06SuJXA+iAMUFBRrhjReayDICIzM8qi0TbsOXlPhn3GK5sDchwidHDtw9VPVOgKeF3xyXlrjIxeA0YdpuA==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.6.tgz",
+      "integrity": "sha512-F2BhRmbC1dJlNA6cdjtbIWQJNV112TYbzEc0/0UFZYvKL52mL0PR0ZrlpIPEludV85WEmjA1RpjW2H5tNQka9g==",
       "license": "MIT",
       "dependencies": {
         "@supabase/phoenix": "0.4.4",
@@ -5623,21 +5623,21 @@
       }
     },
     "node_modules/@supabase/ssr": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.1.tgz",
-      "integrity": "sha512-jBYloKmvVYqFTX/ezriNtb5gL4mR8BktYEDNyF8/JN8VqCawefPMpBKh/qJYXuBPswgHkdVP80yHN3IJDCfBgg==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.3.tgz",
+      "integrity": "sha512-qWXJ/dI7CiYDKyTgIPqJ4Qkh8y5edh2LdF/nkN48z47mmEVzAO2OE+YErYeQ/UemVfonn/F4kFz+lhLqoVMdpw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.2"
       },
       "peerDependencies": {
-        "@supabase/supabase-js": "^2.110.3"
+        "@supabase/supabase-js": "^2.110.5"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.110.4",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.4.tgz",
-      "integrity": "sha512-s7e6KGY3KQQTLWz93xd8qJQpSZMqHQR8Yvigk4aqxdCc/XEzNhF/FiEEUO8bwZ2RrFxCe4rmPlHHd+/OyTATMw==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.6.tgz",
+      "integrity": "sha512-DHS7Jy8MCu2sltDBjANu6oGjeUBUY+bowBnga6CySwtAF2BBKCTJGULnt7wyKPSLSXsoiCyzTwyU1r3SAx++Rg==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -5648,16 +5648,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.110.4",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.4.tgz",
-      "integrity": "sha512-RErQw3rYFu/t23oli4q7Zb+PUiyAv2h2/aoGLJqaY35eBGugmo+Bb7ZByqxssoFcrxT6xVz3hQde53O/6/+HWA==",
+      "version": "2.110.6",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.6.tgz",
+      "integrity": "sha512-UJTAz1NUiSRI2mQYhUPvNMwqfkSucV1iSCcMJz8jgsSUTOfic9C3D6LGNOrH6KTvYUhxRvnf3ktq2Sd3IXIQzQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.110.4",
-        "@supabase/functions-js": "2.110.4",
-        "@supabase/postgrest-js": "2.110.4",
-        "@supabase/realtime-js": "2.110.4",
-        "@supabase/storage-js": "2.110.4"
+        "@supabase/auth-js": "2.110.6",
+        "@supabase/functions-js": "2.110.6",
+        "@supabase/postgrest-js": "2.110.6",
+        "@supabase/realtime-js": "2.110.6",
+        "@supabase/storage-js": "2.110.6"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7422,14 +7422,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "7.0.26",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.26.tgz",
-      "integrity": "sha512-gzLoOHoXFJNcxrzFyHClbZsDEA1z0LNm3Kwq8lEWIfL+8wEEir+eDJqJJbkEJdLxGrc0IuBkybxEDzkbvSavjw==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.29.tgz",
+      "integrity": "sha512-q+A+skhl6SyjWliU6W7zNYgDUrEk5SbNrCc5vt4S9n6+n6e7jSorDmu51hlhjDOsS7VwzWGCgbWFvvT3iomtvg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "4.0.19",
+        "@ai-sdk/gateway": "4.0.21",
         "@ai-sdk/provider": "4.0.3",
-        "@ai-sdk/provider-utils": "5.0.9"
+        "@ai-sdk/provider-utils": "5.0.10"
       },
       "engines": {
         "node": ">=22"
@@ -8083,9 +8083,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001805",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -9586,9 +9586,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.389",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "version": "1.5.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
       "dev": true,
       "license": "ISC"
     },
@@ -15867,13 +15867,13 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.399.5",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.399.5.tgz",
-      "integrity": "sha512-5z7piKHxzZeDhdZ/XtivVHKIFr+09mDPcN3kIIkBS1zHmUTzDhQAR0T3R6NZTLog/8wzhY2jlu16anve1fdMAA==",
+      "version": "1.402.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.402.3.tgz",
+      "integrity": "sha512-MCn4O9wJc1BGBbb820MlmYifDb6EhFBFhfR1K9294gfgFRcxin+NSlypswVBdt1ZO4XD/P7EPmwApyVX/EYlUw==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@posthog/core": "^1.40.2",
-        "@posthog/types": "^1.393.0",
+        "@posthog/core": "^1.42.1",
+        "@posthog/types": "^1.395.0",
         "core-js": "^3.49.0",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",
@@ -15939,9 +15939,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
-      "integrity": "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.1.tgz",
+      "integrity": "sha512-iaFMYqDsE4ffdDkn5qup0j5f2aCEBFZrdrZnvu9QKTlWx/iGPeQ4HHu7b7fCPMxeo9nwQBiOAh2nSypdFYWJkw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16379,9 +16379,9 @@
       }
     },
     "node_modules/react-email": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/react-email/-/react-email-6.8.1.tgz",
-      "integrity": "sha512-qx1n/9h/5zRd7qsLpniQh7P3xgH+7pP+xyYspB1MZBRpHcrFJEbcsIYuPkA0vnRx+3jl9fSpSmXQ8xbXIRySwQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-email/-/react-email-6.9.0.tgz",
+      "integrity": "sha512-72jV+VkeeXgNWDycNDn2tIlHFLg4Hevi3pC77g63FAY1+bDgTs4b56jbZfHF1t5d+GVGb02sGS8bOwoptgvI1w==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "7.29.2",
@@ -17823,9 +17823,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -19864,9 +19864,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/server/import/broker-transactions/import.ts
+++ b/server/import/broker-transactions/import.ts
@@ -75,6 +75,18 @@ export async function importBrokerTransactionsFromCSV(
     };
   }
 
+  // Positions skipped during review are dropped entirely; users can create
+  // them manually later (e.g. instruments the market data provider lacks).
+  const excludedPositionKeys = new Set(options.excludedPositionKeys ?? []);
+  if (excludedPositionKeys.size > 0) {
+    parsed.positions = parsed.positions.filter(
+      (position) => !excludedPositionKeys.has(position.positionKey),
+    );
+    parsed.records = parsed.records.filter(
+      (record) => !excludedPositionKeys.has(record.positionKey),
+    );
+  }
+
   if (parsed.records.length === 0) {
     return {
       success: false,

--- a/server/import/broker-transactions/import.ts
+++ b/server/import/broker-transactions/import.ts
@@ -10,6 +10,10 @@ import { resolveBrokerTransactionInstruments } from "@/server/import/broker-tran
 import { fetchExchangeRates } from "@/server/exchange-rates/fetch";
 
 import { convertCurrency } from "@/lib/currency-conversion";
+import {
+  compareBrokerRecordOrder,
+  inferOpeningQuantity,
+} from "@/lib/import/broker-transactions/adapter-utils";
 import { parseBrokerTransactionsCSV } from "@/lib/import/broker-transactions/registry";
 import { formatUTCDateKey, parseUTCDateKey } from "@/lib/date/date-utils";
 
@@ -32,15 +36,18 @@ function normalizePositionName(value: string) {
 function buildCreatePositionFormData(
   draft: BrokerTransactionPositionDraft,
   symbolId?: string,
+  openingQuantity = 0,
 ) {
   const formData = new FormData();
   formData.append("type", "asset");
   formData.append("name", draft.name);
   formData.append("currency", draft.currency);
   formData.append("category_id", draft.category_id);
-  // Broker transaction imports derive real quantity from records. This zero
-  // snapshot gives recalculation a clean base before the first imported trade.
-  formData.append("quantity", "0");
+  // Broker transaction imports derive real quantity from records. This base
+  // snapshot gives recalculation a clean start before the first imported
+  // trade: zero for full histories, or the inferred pre-export holding when a
+  // date-ranged export sells units it never bought within the window.
+  formData.append("quantity", String(openingQuantity));
   formData.append("unit_value", String(draft.firstUnitValue));
   formData.append("cost_basis_per_unit", String(draft.firstUnitValue));
   formData.append("date", draft.earliestTradeDate);
@@ -143,6 +150,10 @@ export async function importBrokerTransactionsFromCSV(
     (position) =>
       !positionByNormalizedName.has(normalizePositionName(position.name)),
   );
+  const openingBalances = buildBrokerOpeningBalances(
+    missingPositions,
+    parsed.records,
+  );
 
   // Idempotency is enforced twice: this pre-filter avoids noisy retries, while
   // the DB partial unique index protects against concurrent duplicate inserts.
@@ -218,7 +229,11 @@ export async function importBrokerTransactionsFromCSV(
         ? resolution.symbolId
         : undefined;
     const result = await createPosition(
-      buildCreatePositionFormData(convertedDraft, symbolId),
+      buildCreatePositionFormData(
+        convertedDraft,
+        symbolId,
+        openingBalances.openingQuantityByPositionKey.get(draft.positionKey),
+      ),
     );
     if (!result.success) {
       return {
@@ -288,7 +303,11 @@ export async function importBrokerTransactionsFromCSV(
     matchedPositionCount: parsed.positions.length - missingPositions.length,
     skippedCount: parsed.records.length - recordsToImport.length,
     warnings: buildBrokerImportWarnings(
-      [...(parsed.warnings ?? []), ...conversion.warnings],
+      [
+        ...(parsed.warnings ?? []),
+        ...conversion.warnings,
+        ...openingBalances.warnings,
+      ],
       instrumentResolutions,
     ),
   };
@@ -577,6 +596,31 @@ async function convertBrokerImportCurrencies({
   };
 }
 
+// Date-ranged exports can sell units bought before the export window. Infer
+// the pre-window holding per new position so those sells import against an
+// opening balance instead of failing timeline validation.
+function buildBrokerOpeningBalances(
+  positions: BrokerTransactionPositionDraft[],
+  records: BrokerTransactionRecordDraft[],
+) {
+  const openingQuantityByPositionKey = new Map<string, number>();
+  const warnings: string[] = [];
+
+  for (const position of positions) {
+    const openingQuantity = inferOpeningQuantity(
+      records.filter((record) => record.positionKey === position.positionKey),
+    );
+    if (openingQuantity <= 0) continue;
+
+    openingQuantityByPositionKey.set(position.positionKey, openingQuantity);
+    warnings.push(
+      `Inferred an opening balance of ${openingQuantity} unit(s) for "${position.name}" because the export sells units it never buys. Review the position's quantity and cost basis, or delete it and re-import a full-history export.`,
+    );
+  }
+
+  return { openingQuantityByPositionKey, warnings };
+}
+
 function buildBrokerImportWarnings(
   parsedWarnings: string[] | undefined,
   instrumentResolutions: Awaited<
@@ -755,23 +799,6 @@ function prepareBrokerRecords({
     importedTimelineByPosition,
     earliestImportedDateByPosition,
   };
-}
-
-function compareBrokerRecordOrder(
-  left: BrokerTransactionRecordDraft,
-  right: BrokerTransactionRecordDraft,
-) {
-  if (left.date !== right.date) {
-    return left.date.localeCompare(right.date);
-  }
-
-  const leftTime = left.executedAt ?? "";
-  const rightTime = right.executedAt ?? "";
-  if (leftTime !== rightTime) {
-    return leftTime.localeCompare(rightTime);
-  }
-
-  return left.sourceRowNumber - right.sourceRowNumber;
 }
 
 async function validatePreparedBrokerRecords(
@@ -1002,7 +1029,10 @@ export async function previewBrokerImport(
     recordsToImportCount: parsed.records.length - existingTransactionIds.size,
     duplicateRecordsSkippedCount: existingTransactionIds.size,
     ignoredRowCount: parsed.ignoredRowCount,
-    warnings: parsed.warnings ?? [],
+    warnings: [
+      ...(parsed.warnings ?? []),
+      ...buildBrokerOpeningBalances(positionsToCreate, parsed.records).warnings,
+    ],
     resolutions: Array.from(instrumentResolutions.values()),
   };
 }

--- a/server/import/broker-transactions/import.ts
+++ b/server/import/broker-transactions/import.ts
@@ -155,6 +155,7 @@ export async function importBrokerTransactionsFromCSV(
     importSource: parsed.source,
     matchedPositions,
     positionByNormalizedName,
+    records: parsed.records,
   });
   if (!matchedSourceValidation.success) return matchedSourceValidation;
 
@@ -329,6 +330,7 @@ async function validateMatchedBrokerPositionSources({
   importSource,
   matchedPositions,
   positionByNormalizedName,
+  records,
 }: {
   importSource: string;
   matchedPositions: BrokerTransactionPositionDraft[];
@@ -336,6 +338,7 @@ async function validateMatchedBrokerPositionSources({
     string,
     { id: string; name: string; currency: string }
   >;
+  records: BrokerTransactionRecordDraft[];
 }): Promise<ImportActionResult> {
   const matchedPositionIds = matchedPositions
     .map((position) =>
@@ -389,7 +392,7 @@ async function validateMatchedBrokerPositionSources({
   if (positionsWithoutBrokerRecords.length > 0) {
     const { data: snapshots, error: snapshotsError } = await supabase
       .from("position_snapshots")
-      .select("position_id, quantity, portfolio_record_id")
+      .select("position_id, date, quantity, portfolio_record_id")
       .eq("user_id", user.id)
       .in(
         "position_id",
@@ -403,14 +406,38 @@ async function validateMatchedBrokerPositionSources({
       };
     }
 
-    // A broker-created retry position has only a zero bootstrap snapshot. A
-    // non-zero snapshot with no broker records means manual history already
-    // exists and importing transactions would double-count from that base.
+    const draftByPositionId = new Map<string, BrokerTransactionPositionDraft>();
+    for (const draft of matchedPositions) {
+      const existing = positionByNormalizedName.get(
+        normalizePositionName(draft.name),
+      );
+      if (existing) draftByPositionId.set(existing.id, draft);
+    }
+
+    // A broker-created retry position has only its bootstrap snapshot: zero
+    // for full histories, or the inferred opening balance at the earliest
+    // trade date for date-ranged exports. Any other recordless non-zero
+    // snapshot means manual history already exists and importing transactions
+    // would double-count from that base.
     for (const snapshot of snapshots ?? []) {
-      if (
-        snapshot.portfolio_record_id === null &&
-        Math.abs(snapshot.quantity) > 1e-9
-      ) {
+      if (snapshot.portfolio_record_id !== null) continue;
+      if (Math.abs(snapshot.quantity) < 1e-9) continue;
+
+      const draft = draftByPositionId.get(snapshot.position_id);
+      const inferredOpening = draft
+        ? inferOpeningQuantity(
+            records.filter(
+              (record) => record.positionKey === draft.positionKey,
+            ),
+          )
+        : 0;
+      const isInferredBootstrap =
+        draft &&
+        inferredOpening > 0 &&
+        snapshot.date === draft.earliestTradeDate &&
+        Math.abs(snapshot.quantity - inferredOpening) < 1e-9;
+
+      if (!isInferredBootstrap) {
         unsafePositionIds.add(snapshot.position_id);
       }
     }
@@ -1015,6 +1042,7 @@ export async function previewBrokerImport(
     importSource: parsed.source,
     matchedPositions,
     positionByNormalizedName,
+    records: parsed.records,
   });
   if (!matchedSourceValidation.success) {
     return {

--- a/server/import/broker-transactions/instrument-resolution.test.ts
+++ b/server/import/broker-transactions/instrument-resolution.test.ts
@@ -399,6 +399,87 @@ describe("broker instrument resolution", () => {
     expect(fetchYahooFinanceSymbolMock).toHaveBeenCalledWith("ACME.DE");
   });
 
+  it("honors a user-selected ticker when the broker row has no symbol", async () => {
+    const noSymbolPosition: BrokerTransactionPositionDraft = {
+      ...basePosition,
+      positionKey: "trade_republic::acme",
+      brokerSymbol: null,
+    };
+    fetchYahooFinanceSymbolMock.mockResolvedValue({
+      success: true,
+      data: {
+        ticker: "ACME.DE",
+        long_name: "Acme",
+        short_name: "Acme",
+        exchange: "GER",
+        quote_type: "EQUITY",
+        currency: "EUR",
+      },
+    });
+    createSymbolMock.mockResolvedValue({
+      success: true,
+      data: { id: "symbol-1" },
+    });
+
+    const { resolveBrokerTransactionInstruments } =
+      await import("./instrument-resolution");
+    const result = await resolveBrokerTransactionInstruments({
+      positions: [noSymbolPosition],
+      importSource: "trade_republic",
+      selectedSymbolTickers: {
+        [noSymbolPosition.positionKey]: "ACME.DE",
+      },
+    });
+
+    expect(result.get(noSymbolPosition.positionKey)).toMatchObject({
+      state: "auto_linked",
+      symbolId: "symbol-1",
+      selectedTicker: "ACME.DE",
+    });
+    // No broker symbol means there is no ISIN alias to persist.
+    expect(upsertSymbolAliasMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps mutual fund name-search results as candidates", async () => {
+    resolveSymbolInputMock.mockResolvedValue(null);
+    searchYahooFinanceSymbolsMock.mockImplementation(
+      async ({ query }: { query: string }) =>
+        query === "US0000000001"
+          ? { success: true, data: [] }
+          : {
+              success: true,
+              data: [{ id: "FUNDX", typeDisp: "Mutual Fund" }],
+            },
+    );
+    fetchYahooFinanceSymbolMock.mockResolvedValue({
+      success: true,
+      data: {
+        ticker: "FUNDX",
+        long_name: "Fund X",
+        short_name: "Fund X",
+        exchange: "NAS",
+        quote_type: "MUTUALFUND",
+        currency: "EUR",
+      },
+    });
+    createSymbolMock.mockResolvedValue({
+      success: true,
+      data: { id: "symbol-1" },
+    });
+
+    const { resolveBrokerTransactionInstruments } =
+      await import("./instrument-resolution");
+    const result = await resolveBrokerTransactionInstruments({
+      positions: [basePosition],
+      importSource: "trade_republic",
+    });
+
+    expect(result.get(basePosition.positionKey)).toMatchObject({
+      state: "auto_linked",
+      selectedTicker: "FUNDX",
+    });
+  });
+
   it("returns unresolved when no usable candidates are found", async () => {
     resolveSymbolInputMock.mockResolvedValue(null);
     searchYahooFinanceSymbolsMock.mockResolvedValue({

--- a/server/import/broker-transactions/instrument-resolution.test.ts
+++ b/server/import/broker-transactions/instrument-resolution.test.ts
@@ -352,6 +352,53 @@ describe("broker instrument resolution", () => {
     });
   });
 
+  it("filters non-security quote types out of fuzzy name-search results", async () => {
+    resolveSymbolInputMock.mockResolvedValue(null);
+    searchYahooFinanceSymbolsMock.mockImplementation(
+      async ({ query }: { query: string }) =>
+        query === "US0000000001"
+          ? { success: true, data: [{ id: "ACME.DE", typeDisp: "ETF" }] }
+          : {
+              success: true,
+              data: [
+                { id: "ALI=F", typeDisp: "Futures" },
+                { id: "EURUSD=X", typeDisp: "Currency" },
+              ],
+            },
+    );
+    fetchYahooFinanceSymbolMock.mockResolvedValue({
+      success: true,
+      data: {
+        ticker: "ACME.DE",
+        long_name: "Acme",
+        short_name: "Acme",
+        exchange: "GER",
+        quote_type: "ETF",
+        currency: "EUR",
+      },
+    });
+    createSymbolMock.mockResolvedValue({
+      success: true,
+      data: { id: "symbol-1" },
+    });
+
+    const { resolveBrokerTransactionInstruments } =
+      await import("./instrument-resolution");
+    const result = await resolveBrokerTransactionInstruments({
+      positions: [basePosition],
+      importSource: "trade_republic",
+    });
+
+    // Name-search junk never becomes a candidate, so the single ISIN match
+    // auto-links and the junk tickers are never fetched.
+    expect(result.get(basePosition.positionKey)).toMatchObject({
+      state: "auto_linked",
+      selectedTicker: "ACME.DE",
+    });
+    expect(fetchYahooFinanceSymbolMock).toHaveBeenCalledTimes(1);
+    expect(fetchYahooFinanceSymbolMock).toHaveBeenCalledWith("ACME.DE");
+  });
+
   it("returns unresolved when no usable candidates are found", async () => {
     resolveSymbolInputMock.mockResolvedValue(null);
     searchYahooFinanceSymbolsMock.mockResolvedValue({

--- a/server/import/broker-transactions/instrument-resolution.ts
+++ b/server/import/broker-transactions/instrument-resolution.ts
@@ -52,6 +52,8 @@ export type BrokerInstrumentResolution =
 export interface BrokerTransactionImportRequestOptions {
   selectedSymbolTickers?: Record<string, string>;
   manualPositionKeys?: string[];
+  // Positions skipped during review; they and their records are not imported.
+  excludedPositionKeys?: string[];
 }
 
 export type BrokerTransactionImportPreview =

--- a/server/import/broker-transactions/instrument-resolution.ts
+++ b/server/import/broker-transactions/instrument-resolution.ts
@@ -15,6 +15,9 @@ import type { Symbol } from "@/types/global.types";
 
 const ISIN_PATTERN = /^[A-Z]{2}[A-Z0-9]{9}\d$/;
 const SYMBOL_SEARCH_LIMIT = 5;
+// Broker trades are securities, so fuzzy name-search results outside these
+// quote types (futures, FX, indexes) are noise, not candidates.
+const NAME_SEARCH_QUOTE_TYPES = new Set(["equity", "etf", "fund"]);
 
 export interface BrokerInstrumentCandidate {
   ticker: string;
@@ -348,6 +351,7 @@ async function findProviderCandidates(options: {
   const tickers = new Set<string>();
 
   for (const query of queries) {
+    const isNameQuery = query !== options.brokerSymbol;
     const result = await searchYahooFinanceSymbols({
       query,
       limit: SYMBOL_SEARCH_LIMIT,
@@ -355,6 +359,14 @@ async function findProviderCandidates(options: {
     if (!result.success) continue;
 
     for (const match of result.data ?? []) {
+      // Exact broker-symbol/ISIN matches pass through unfiltered; only the
+      // fuzzy name search is restricted to security quote types.
+      if (
+        isNameQuery &&
+        !NAME_SEARCH_QUOTE_TYPES.has((match.typeDisp ?? "").toLowerCase())
+      ) {
+        continue;
+      }
       tickers.add(match.id.trim().toUpperCase());
     }
   }

--- a/server/import/broker-transactions/instrument-resolution.ts
+++ b/server/import/broker-transactions/instrument-resolution.ts
@@ -17,7 +17,13 @@ const ISIN_PATTERN = /^[A-Z]{2}[A-Z0-9]{9}\d$/;
 const SYMBOL_SEARCH_LIMIT = 5;
 // Broker trades are securities, so fuzzy name-search results outside these
 // quote types (futures, FX, indexes) are noise, not candidates.
-const NAME_SEARCH_QUOTE_TYPES = new Set(["equity", "etf", "fund"]);
+const NAME_SEARCH_QUOTE_TYPES = new Set([
+  "equity",
+  "etf",
+  "fund",
+  "mutual fund",
+  "mutualfund",
+]);
 
 export interface BrokerInstrumentCandidate {
   ticker: string;
@@ -102,15 +108,13 @@ async function resolveBrokerTransactionInstrument(options: {
   persistMatches: boolean;
 }): Promise<BrokerInstrumentResolution> {
   const { position, importSource, selectedTicker, persistMatches } = options;
-  const brokerSymbol = position.brokerSymbol?.trim().toUpperCase();
-  if (!brokerSymbol) {
-    return unresolved(position, "No broker symbol was provided.");
-  }
-
+  const brokerSymbol = position.brokerSymbol?.trim().toUpperCase() ?? "";
   const isIsin = isIsinLike(brokerSymbol);
-  // 1. User review choices win. 2. Broker-scoped ISIN aliases seed candidates.
-  // 3. A single ISIN candidate can auto-link; multiple ISIN listings need
-  // review because Trade Republic transaction currency is settlement currency.
+
+  // 1. User review choices win, including for rows without a broker symbol.
+  // 2. Broker-scoped ISIN aliases seed candidates. 3. A single ISIN candidate
+  // can auto-link; multiple ISIN listings need review because Trade Republic
+  // transaction currency is settlement currency.
   if (selectedTicker?.trim()) {
     return resolveSelectedTicker({
       position,
@@ -120,6 +124,10 @@ async function resolveBrokerTransactionInstrument(options: {
       selectedTicker,
       persistMatches,
     });
+  }
+
+  if (!brokerSymbol) {
+    return unresolved(position, "No broker symbol was provided.");
   }
 
   const aliasType = isIsin ? "isin" : "ticker";


### PR DESCRIPTION
## Summary
Adds support for importing broker transactions from Directa and Scalable Capital, expanding the broker CSV import feature beyond Trade Republic. Includes adapter implementations, comprehensive test coverage, and UI enhancements to handle position exclusion during import review.

## Key Changes

**New Broker Adapters:**
- `directaAdapter`: Parses Directa "Movimenti" exports with metadata preamble, dd/mm/yyyy dates, and derived unit prices from gross amounts
- `scalableCapitalAdapter`: Parses Scalable Capital transaction exports with EU number formats and savings plan support
- Both adapters use synthetic transaction IDs for idempotent re-uploads and handle position-specific currency conversions

**Core Infrastructure:**
- `adapter-utils.ts`: Shared utilities for synthetic ID generation, record ordering, and opening quantity inference (handles date-ranged exports with pre-window sells)
- Updated `registry.ts` to register new adapters and expose `getBrokerDisplayName()` and `listSupportedBrokerDisplayNames()`
- Enhanced `BrokerTransactionAdapter` type to receive raw CSV content instead of just headers

**Import Logic:**
- `importBrokerTransactionsFromCSV()` now supports position exclusion via `excludedPositionKeys` option
- Opening quantity inference for positions with sells predating the export window
- Improved error handling and validation for both adapters

**UI Enhancements:**
- `BrokerTransactionResults` component now supports skipping positions during review (e.g., for instruments lacking market data)
- Added "Skip" button to exclude positions from import
- Integrated `SymbolSearch` with context-specific ISIN candidates via `defaultResults` prop
- Improved messaging for excluded vs. unresolved positions

**Tests & Documentation:**
- Comprehensive test suites for both adapters covering edge cases (FX trades, commission rows, synthetic IDs, date parsing)
- Test for opening quantity inference with interleaved buy/sell histories
- Updated instrument resolution tests to filter non-security quote types from fuzzy search results
- Added ponytail skill documentation (lazy development principles)

## Notable Implementation Details

- Directa adapter locates the header row dynamically (skips metadata preamble) and handles Windows-1252 encoding artifacts in column names
- Both adapters normalize position keys consistently for deduplication across multiple fills
- Synthetic transaction IDs include occurrence suffixes to handle identical rows (e.g., multiple fills of one order)
- Opening quantity calculation uses running balance tracking to find the largest shortfall across the record timeline
- Symbol search now filters results to security types only (excludes futures, FX, indexes) for broker imports

https://claude.ai/code/session_01AAPRhW8HG6BuBNPh6d9YLa