### PR TITLE
fix(import): accept dash-separated dates in Directa exports

### DIFF
--- a/lib/import/broker-transactions/adapters/directa.ts
+++ b/lib/import/broker-transactions/adapters/directa.ts
@@ -63,12 +63,13 @@ function findHeaderRecordIndex(csvContent: string): number {
   return splitCSVRecords(csvContent).findIndex(isDirectaHeaderRecord);
 }
 
-// Directa dates are dd/mm/yyyy.
+// Directa dates are day-first: direct downloads use dd-mm-yyyy, while
+// Excel round-trips of the same export produce dd/mm/yyyy.
 function parseDirectaDateKey(raw: string): string | null {
-  const match = raw.trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  const match = raw.trim().match(/^(\d{1,2})([/-])(\d{1,2})\2(\d{4})$/);
   if (!match) return null;
 
-  const dateKey = `${match[3]}-${match[2].padStart(2, "0")}-${match[1].padStart(2, "0")}`;
+  const dateKey = `${match[4]}-${match[3].padStart(2, "0")}-${match[1].padStart(2, "0")}`;
   return Number.isNaN(parseUTCDateKey(dateKey).getTime()) ? null : dateKey;
 }
 

--- a/lib/import/broker-transactions/directa.test.ts
+++ b/lib/import/broker-transactions/directa.test.ts
@@ -127,6 +127,40 @@ describe("Directa broker transaction adapter", () => {
     ).toEqual(idsA);
   });
 
+  it("parses dash-separated dates from direct Directa downloads", async () => {
+    // Files downloaded straight from Directa use dd-mm-yyyy; only Excel
+    // round-trips convert them to dd/mm/yyyy.
+    const csv = buildDirectaCSV([
+      "15-07-2026;17-07-2026;Acquisto;VWCE;IE0000000001;;World ETF;9;-1492,11;0;EUR;19617283132458",
+      "13-07-2026;13-07-2026;Conferimento con bonifico;;;19197957;;0;1500;0;EUR;",
+    ]);
+
+    const result = await parseBrokerTransactionsCSV(csv);
+
+    expect(result.success).toBe(true);
+    expect(result.records).toEqual([
+      expect.objectContaining({
+        type: "buy",
+        date: "2026-07-15",
+        quantity: 9,
+      }),
+    ]);
+    expect(result.ignoredRowCount).toBe(1);
+  });
+
+  it("rejects mixed date separators within one date", async () => {
+    const csv = buildDirectaCSV([
+      "15-07/2026;17-07-2026;Acquisto;VWCE;IE0000000001;;World ETF;9;-1492,11;0;EUR;X1",
+    ]);
+
+    const result = await parseBrokerTransactionsCSV(csv);
+
+    expect(result.success).toBe(false);
+    expect(result.errors?.some((error) => error.includes("Invalid date"))).toBe(
+      true,
+    );
+  });
+
   it("rejects rows that mix trade currencies for one instrument", async () => {
     const csv = buildDirectaCSV([
       "16/01/2026;20/01/2026;Vendita;.ACME;US0000000001;;ACME INC;1;50,00;60,00;USD;X2",


### PR DESCRIPTION
## Summary

Files downloaded directly from Directa use `dd-mm-yyyy` dates. The sample the first adapter was built from had been through an Excel round-trip that rewrote dates to `dd/mm/yyyy`, and the parser only accepted slashes — so fresh "Tutti i movimenti" exports failed every row with "Invalid date" (user-reported, screenshot-confirmed). The date parser now accepts both separators; a mixed separator within one date still fails.

No other changes were needed for the "Tutti i movimenti" export variant: its additional row types (deposits, stamp duty, coupons, dividends, withholding) already fall through the Acquisto/Vendita type filter as ignored non-trade rows.

## Test plan

- [x] 58 unit tests pass, including two new date-separator cases
- [x] Verified against the reporting user's real export: 50 trades / 9 positions parsed, 120 non-trade rows ignored, zero errors (file not committed for privacy)
- [x] Synthetic transaction IDs are identical between the dash-date and slash-date variants of the same export, so re-uploads keep deduplicating correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAPRhW8HG6BuBNPh6d9YLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAPRhW8HG6BuBNPh6d9YLa)_