### PR TITLE
feat(ai): approval-gated portfolio write tools for the AI advisor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ MAINTENANCE_MODE=false
 # AI
 AI_PROVIDER=openai
 AI_PROVIDER_API_KEY=your_provider_api_key
+# Signs AI tool-approval requests (HMAC); recommended in production
+TOOL_APPROVAL_SECRET=generate_a_long_random_secret
 
 # Replicate API
 REPLICATE_API_TOKEN=your_replicate_api_token

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/app/api/ai/chat/route.test.ts
+++ b/app/api/ai/chat/route.test.ts
@@ -492,6 +492,45 @@ describe("POST /api/ai/chat", () => {
     });
   });
 
+  it("gates write tools behind user approval and passes the signing secret", async () => {
+    vi.stubEnv("TOOL_APPROVAL_SECRET", "test-approval-secret");
+
+    try {
+      const { POST } = await import("@/app/api/ai/chat/route");
+      fetchProfileMock.mockResolvedValue({
+        profile: { data_sharing_consent: true },
+      });
+
+      const request = new Request("http://localhost/api/ai/chat", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            {
+              id: "m-1",
+              role: "user",
+              parts: [{ type: "text", text: "I bought 20 AAPL today" }],
+            },
+          ],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      await POST(request);
+
+      expect(streamTextMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolApproval: {
+            createPortfolioRecord: "user-approval",
+            createPosition: "user-approval",
+          },
+          experimental_toolApprovalSecret: "test-approval-secret",
+        }),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("passes regenerate replacement metadata to assistant persistence", async () => {
     const { POST } = await import("@/app/api/ai/chat/route");
     fetchProfileMock.mockResolvedValue({

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -60,7 +60,13 @@ const validModes = new Set<Mode>(["educational", "advisory", "unhinged"]);
 type ChatUIMessage = UIMessage<unknown, never, InferUITools<typeof aiTools>>;
 
 // Unsigned approvals let a tampered client alter write-tool inputs between
-// propose and approve, so flag a missing secret loudly in production.
+// propose and approve, so in production a missing secret disables the write
+// tools entirely (fail closed) and warns loudly.
+const AI_WRITE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "createPortfolioRecord",
+  "createPosition",
+]);
+
 let warnedMissingToolApprovalSecret = false;
 function resolveToolApprovalSecret(): string | undefined {
   const secret = process.env.TOOL_APPROVAL_SECRET?.trim() || undefined;
@@ -72,7 +78,7 @@ function resolveToolApprovalSecret(): string | undefined {
   ) {
     warnedMissingToolApprovalSecret = true;
     console.warn(
-      "TOOL_APPROVAL_SECRET is not set: AI write-tool approvals are unsigned.",
+      "TOOL_APPROVAL_SECRET is not set: AI write tools are disabled (fail closed).",
     );
   }
 
@@ -237,13 +243,31 @@ export async function POST(req: Request) {
 
   // 4. Bound model context size to keep latency/cost predictable.
   const guardrailedContextMessages = buildGuardrailedModelContext(messages);
+
+  // Fail closed: without a signing secret in production the SDK cannot bind
+  // the user's Approve click to the original tool inputs, so drop the write
+  // tools from the request entirely (message validation above still uses the
+  // full set so historical write parts keep parsing).
+  const toolApprovalSecret = resolveToolApprovalSecret();
+  const includeWriteTools =
+    toolApprovalSecret !== undefined || process.env.NODE_ENV !== "production";
+  const enabledAiTools = includeWriteTools
+    ? aiTools
+    : // Cast keeps the full toolset type to avoid generic churn below; the
+      // absent write tools are simply never callable.
+      (Object.fromEntries(
+        Object.entries(aiTools).filter(
+          ([toolName]) => !AI_WRITE_TOOL_NAMES.has(toolName),
+        ),
+      ) as typeof aiTools);
+
   const instructions = createSystemPrompt({
     mode,
-    aiTools,
+    aiTools: enabledAiTools,
     currentDateKey,
   });
   const firstAssistantTurn = !messages.some((m) => m.role === "assistant");
-  const { guardedTools, guardState } = createToolCallGuard(aiTools, {
+  const { guardedTools, guardState } = createToolCallGuard(enabledAiTools, {
     maxTotalCallsPerTurn: MAX_TOOL_CALLS_PER_TURN,
     maxCallsPerToolPerTurn: MAX_CALLS_PER_TOOL_PER_TURN,
     enableExactInputDeduplication: true,
@@ -261,13 +285,13 @@ export async function POST(req: Request) {
       createPortfolioRecord: "user-approval",
       createPosition: "user-approval",
     },
-    experimental_toolApprovalSecret: resolveToolApprovalSecret(),
+    experimental_toolApprovalSecret: toolApprovalSecret,
     ...chatGenerationOptions,
 
     // Force portfolio overview on very first assistant step
     prepareStep: async ({ stepNumber }) => {
       const availableTools = (
-        Object.keys(aiTools) as Array<keyof typeof aiTools>
+        Object.keys(enabledAiTools) as Array<keyof typeof aiTools>
       ).filter(
         (toolName) =>
           guardState.getCallsForTool(String(toolName)) <

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -59,6 +59,26 @@ const chatRequestSchema = z.looseObject({
 const validModes = new Set<Mode>(["educational", "advisory", "unhinged"]);
 type ChatUIMessage = UIMessage<unknown, never, InferUITools<typeof aiTools>>;
 
+// Unsigned approvals let a tampered client alter write-tool inputs between
+// propose and approve, so flag a missing secret loudly in production.
+let warnedMissingToolApprovalSecret = false;
+function resolveToolApprovalSecret(): string | undefined {
+  const secret = process.env.TOOL_APPROVAL_SECRET?.trim() || undefined;
+
+  if (
+    !secret &&
+    process.env.NODE_ENV === "production" &&
+    !warnedMissingToolApprovalSecret
+  ) {
+    warnedMissingToolApprovalSecret = true;
+    console.warn(
+      "TOOL_APPROVAL_SECRET is not set: AI write-tool approvals are unsigned.",
+    );
+  }
+
+  return secret;
+}
+
 // Resolve the prompt source from the request payload
 function resolvePromptSource(
   promptSource: string | undefined,
@@ -241,8 +261,7 @@ export async function POST(req: Request) {
       createPortfolioRecord: "user-approval",
       createPosition: "user-approval",
     },
-    experimental_toolApprovalSecret:
-      process.env.TOOL_APPROVAL_SECRET?.trim() || undefined,
+    experimental_toolApprovalSecret: resolveToolApprovalSecret(),
     ...chatGenerationOptions,
 
     // Force portfolio overview on very first assistant step

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -236,6 +236,13 @@ export async function POST(req: Request) {
     instructions,
     maxOutputTokens: 8000,
     stopWhen: [isStepCount(24)],
+    // Portfolio writes require an explicit user approval round-trip.
+    toolApproval: {
+      createPortfolioRecord: "user-approval",
+      createPosition: "user-approval",
+    },
+    experimental_toolApprovalSecret:
+      process.env.TOOL_APPROVAL_SECRET?.trim() || undefined,
     ...chatGenerationOptions,
 
     // Force portfolio overview on very first assistant step

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -16,6 +16,7 @@ import {
 } from "ai";
 import { z } from "zod";
 
+import { AI_WRITE_TOOL_NAMES } from "@/lib/ai/write-tools";
 import { fetchProfile } from "@/server/profile/actions";
 import { createSystemPrompt, type Mode } from "@/server/ai/system-prompt";
 import { aiTools } from "@/server/ai/tools";
@@ -62,11 +63,6 @@ type ChatUIMessage = UIMessage<unknown, never, InferUITools<typeof aiTools>>;
 // Unsigned approvals let a tampered client alter write-tool inputs between
 // propose and approve, so in production a missing secret disables the write
 // tools entirely (fail closed) and warns loudly.
-const AI_WRITE_TOOL_NAMES: ReadonlySet<string> = new Set([
-  "createPortfolioRecord",
-  "createPosition",
-]);
-
 let warnedMissingToolApprovalSecret = false;
 function resolveToolApprovalSecret(): string | undefined {
   const secret = process.env.TOOL_APPROVAL_SECRET?.trim() || undefined;

--- a/components/ai-elements/confirmation.tsx
+++ b/components/ai-elements/confirmation.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { ToolUIPart } from "ai";
+import type { ComponentProps, ReactNode } from "react";
+import { createContext, useContext, useMemo } from "react";
+
+type ToolUIPartApproval =
+  | {
+      id: string;
+      approved?: never;
+      reason?: never;
+    }
+  | {
+      id: string;
+      approved: boolean;
+      reason?: string;
+    }
+  | {
+      id: string;
+      approved: true;
+      reason?: string;
+    }
+  | {
+      id: string;
+      approved: true;
+      reason?: string;
+    }
+  | {
+      id: string;
+      approved: false;
+      reason?: string;
+    }
+  | undefined;
+
+interface ConfirmationContextValue {
+  approval: ToolUIPartApproval;
+  state: ToolUIPart["state"];
+}
+
+const ConfirmationContext = createContext<ConfirmationContextValue | null>(
+  null
+);
+
+const useConfirmation = () => {
+  const context = useContext(ConfirmationContext);
+
+  if (!context) {
+    throw new Error("Confirmation components must be used within Confirmation");
+  }
+
+  return context;
+};
+
+export type ConfirmationProps = ComponentProps<typeof Alert> & {
+  approval?: ToolUIPartApproval;
+  state: ToolUIPart["state"];
+};
+
+export const Confirmation = ({
+  className,
+  approval,
+  state,
+  ...props
+}: ConfirmationProps) => {
+  const contextValue = useMemo(() => ({ approval, state }), [approval, state]);
+
+  if (!approval || state === "input-streaming" || state === "input-available") {
+    return null;
+  }
+
+  return (
+    <ConfirmationContext.Provider value={contextValue}>
+      <Alert className={cn("flex flex-col gap-2", className)} {...props} />
+    </ConfirmationContext.Provider>
+  );
+};
+
+export type ConfirmationTitleProps = ComponentProps<typeof AlertDescription>;
+
+export const ConfirmationTitle = ({
+  className,
+  ...props
+}: ConfirmationTitleProps) => (
+  <AlertDescription className={cn("inline", className)} {...props} />
+);
+
+export interface ConfirmationRequestProps {
+  children?: ReactNode;
+}
+
+export const ConfirmationRequest = ({ children }: ConfirmationRequestProps) => {
+  const { state } = useConfirmation();
+
+  // Only show when approval is requested
+  if (state !== "approval-requested") {
+    return null;
+  }
+
+  return children;
+};
+
+export interface ConfirmationAcceptedProps {
+  children?: ReactNode;
+}
+
+export const ConfirmationAccepted = ({
+  children,
+}: ConfirmationAcceptedProps) => {
+  const { approval, state } = useConfirmation();
+
+  // Only show when approved and in response states
+  if (
+    !approval?.approved ||
+    (state !== "approval-responded" &&
+      state !== "output-denied" &&
+      state !== "output-available")
+  ) {
+    return null;
+  }
+
+  return children;
+};
+
+export interface ConfirmationRejectedProps {
+  children?: ReactNode;
+}
+
+export const ConfirmationRejected = ({
+  children,
+}: ConfirmationRejectedProps) => {
+  const { approval, state } = useConfirmation();
+
+  // Only show when rejected and in response states
+  if (
+    approval?.approved !== false ||
+    (state !== "approval-responded" &&
+      state !== "output-denied" &&
+      state !== "output-available")
+  ) {
+    return null;
+  }
+
+  return children;
+};
+
+export type ConfirmationActionsProps = ComponentProps<"div">;
+
+export const ConfirmationActions = ({
+  className,
+  ...props
+}: ConfirmationActionsProps) => {
+  const { state } = useConfirmation();
+
+  // Only show when approval is requested
+  if (state !== "approval-requested") {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn("flex items-center justify-end gap-2 self-end", className)}
+      {...props}
+    />
+  );
+};
+
+export type ConfirmationActionProps = ComponentProps<typeof Button>;
+
+export const ConfirmationAction = (props: ConfirmationActionProps) => (
+  <Button className="h-8 px-3 text-sm" type="button" {...props} />
+);

--- a/components/dashboard/ai-chat/chat.test.tsx
+++ b/components/dashboard/ai-chat/chat.test.tsx
@@ -673,7 +673,14 @@ describe("Chat guardrail UI", () => {
           {
             type: "tool-createPortfolioRecord",
             state: "approval-requested",
-            input: { summary: "Buy 20 × AAPL @ 211.50 USD on 2026-07-18" },
+            input: {
+              summary: "Buy 20 × AAPL @ 211.50 USD on 2026-07-18",
+              type: "buy",
+              quantity: 20,
+              unitValue: 211.5,
+              date: "2026-07-18",
+              description: null,
+            },
             approval: { id: "approval-1" },
           },
         ],
@@ -685,6 +692,13 @@ describe("Chat guardrail UI", () => {
     expect(
       screen.getByText("Buy 20 × AAPL @ 211.50 USD on 2026-07-18"),
     ).not.toBeNull();
+    // The executable args are shown alongside the model-written summary.
+    expect(screen.getByText("quantity")).not.toBeNull();
+    expect(screen.getByText("20")).not.toBeNull();
+    expect(screen.getByText("211.5")).not.toBeNull();
+    // Null optionals and the summary itself are not listed as detail rows.
+    expect(screen.queryByText("description")).toBeNull();
+    expect(screen.queryByText("summary")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
     expect(hoistedMocks.addToolApprovalResponseMock).toHaveBeenCalledWith({
@@ -750,6 +764,32 @@ describe("Chat guardrail UI", () => {
 
     fireEvent.submit(submitButton.closest("form") as HTMLFormElement);
     expect(hoistedMocks.sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("disables regenerate while an approval is pending", () => {
+    hoistedMocks.messages = [
+      {
+        id: "message-approval",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "I can record that buy for you." },
+          {
+            type: "tool-createPortfolioRecord",
+            state: "approval-requested",
+            input: { summary: "Buy 20 × AAPL @ 211.50 USD on 2026-07-18" },
+            approval: { id: "approval-1" },
+          },
+        ],
+      },
+    ];
+
+    const { container } = renderChat();
+
+    const regenerateButton = container.querySelector(
+      'button[tooltip="Regenerate response"]',
+    ) as HTMLButtonElement | null;
+    expect(regenerateButton).not.toBeNull();
+    expect(regenerateButton?.disabled).toBe(true);
   });
 
   it("refreshes the dashboard only after a successful write", async () => {

--- a/components/dashboard/ai-chat/chat.test.tsx
+++ b/components/dashboard/ai-chat/chat.test.tsx
@@ -9,10 +9,23 @@ const hoistedMocks = vi.hoisted(() => ({
   sendMessageMock: vi.fn(),
   regenerateMock: vi.fn(),
   setMessagesMock: vi.fn(),
+  addToolApprovalResponseMock: vi.fn(),
+  routerRefreshMock: vi.fn(),
+  capturedOnFinish: null as
+    | ((args: {
+        message: unknown;
+        isAbort: boolean;
+        isError: boolean;
+      }) => Promise<void> | void)
+    | null,
   chatError: null as Error | null,
   promptSubmitPayload: { text: "hello", files: [] as unknown[] },
   messages: [] as unknown[],
   status: "ready" as "ready" | "streaming" | "submitted",
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: hoistedMocks.routerRefreshMock }),
 }));
 
 vi.mock("@/hooks/use-copy-to-clipboard", () => ({
@@ -238,12 +251,24 @@ vi.mock("@/components/ui/logos/logomark", () => ({
 }));
 
 vi.mock("@ai-sdk/react", () => ({
-  useChat: ({ onError }: { onError?: (error: Error) => void }) => {
+  useChat: ({
+    onError,
+    onFinish,
+  }: {
+    onError?: (error: Error) => void;
+    onFinish?: (args: {
+      message: unknown;
+      isAbort: boolean;
+      isError: boolean;
+    }) => Promise<void> | void;
+  }) => {
     if (hoistedMocks.chatError) {
       const error = hoistedMocks.chatError;
       hoistedMocks.chatError = null;
       onError?.(error);
     }
+
+    hoistedMocks.capturedOnFinish = onFinish ?? null;
 
     return {
       messages: hoistedMocks.messages,
@@ -252,6 +277,7 @@ vi.mock("@ai-sdk/react", () => ({
       status: hoistedMocks.status,
       stop: vi.fn(),
       regenerate: hoistedMocks.regenerateMock,
+      addToolApprovalResponse: hoistedMocks.addToolApprovalResponseMock,
     };
   },
 }));
@@ -283,6 +309,9 @@ describe("Chat guardrail UI", () => {
     hoistedMocks.setMessagesMock.mockReset();
     hoistedMocks.sendMessageMock.mockReset();
     hoistedMocks.regenerateMock.mockReset();
+    hoistedMocks.addToolApprovalResponseMock.mockReset();
+    hoistedMocks.routerRefreshMock.mockReset();
+    hoistedMocks.capturedOnFinish = null;
   });
 
   it("shows proactive conversation-cap alert for unsaved thread", () => {
@@ -633,5 +662,127 @@ describe("Chat guardrail UI", () => {
     ).not.toBeNull();
     expect(screen.getByText('tool-input:{"ticker":"AAPL"}')).not.toBeNull();
     expect(screen.getByText('tool-output:{"price":123.45}')).not.toBeNull();
+  });
+
+  it("renders the approval card and forwards approve/deny responses", () => {
+    hoistedMocks.messages = [
+      {
+        id: "message-approval",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-createPortfolioRecord",
+            state: "approval-requested",
+            input: { summary: "Buy 20 × AAPL @ 211.50 USD on 2026-07-18" },
+            approval: { id: "approval-1" },
+          },
+        ],
+      },
+    ];
+
+    renderChat();
+
+    expect(
+      screen.getByText("Buy 20 × AAPL @ 211.50 USD on 2026-07-18"),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    expect(hoistedMocks.addToolApprovalResponseMock).toHaveBeenCalledWith({
+      id: "approval-1",
+      approved: true,
+      reason: undefined,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+    expect(hoistedMocks.addToolApprovalResponseMock).toHaveBeenCalledWith({
+      id: "approval-1",
+      approved: false,
+      reason: "User denied this action.",
+    });
+  });
+
+  it("shows the resolved approval state without action buttons", () => {
+    hoistedMocks.messages = [
+      {
+        id: "message-approved",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-createPortfolioRecord",
+            state: "output-available",
+            input: { summary: "Buy 20 × AAPL @ 211.50 USD on 2026-07-18" },
+            output: { success: true },
+            approval: { id: "approval-1", approved: true },
+          },
+        ],
+      },
+    ];
+
+    renderChat();
+
+    expect(screen.getByText("You approved this action.")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Deny" })).toBeNull();
+  });
+
+  it("blocks new submissions while an approval is pending", () => {
+    hoistedMocks.messages = [
+      {
+        id: "message-approval",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-createPortfolioRecord",
+            state: "approval-requested",
+            input: { summary: "Buy 20 × AAPL @ 211.50 USD on 2026-07-18" },
+            approval: { id: "approval-1" },
+          },
+        ],
+      },
+    ];
+
+    renderChat();
+
+    const submitButton = screen.getAllByRole("button", {
+      name: "Send",
+    })[0] as HTMLButtonElement;
+    expect(submitButton.disabled).toBe(true);
+
+    fireEvent.submit(submitButton.closest("form") as HTMLFormElement);
+    expect(hoistedMocks.sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the dashboard only after a successful write", async () => {
+    renderChat();
+
+    await hoistedMocks.capturedOnFinish?.({
+      message: {
+        id: "assistant-plain",
+        role: "assistant",
+        parts: [{ type: "text", text: "no writes here" }],
+      },
+      isAbort: false,
+      isError: false,
+    });
+    expect(hoistedMocks.routerRefreshMock).not.toHaveBeenCalled();
+
+    await hoistedMocks.capturedOnFinish?.({
+      message: {
+        id: "assistant-write",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-createPosition",
+            state: "output-available",
+            input: { summary: "Add position VWCE.DE" },
+            output: { success: true },
+            approval: { id: "approval-2", approved: true },
+          },
+        ],
+      },
+      isAbort: false,
+      isError: false,
+    });
+    expect(hoistedMocks.routerRefreshMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/dashboard/ai-chat/chat.tsx
+++ b/components/dashboard/ai-chat/chat.tsx
@@ -40,7 +40,9 @@ import { DisabledState } from "./disabled-state";
 import { ChatSuggestions } from "./suggestions";
 import { ChatThread } from "./thread";
 import type { ChatProps } from "./types";
-import { hasPendingApprovalRequest, messageHasSuccessfulWrite } from "./utils";
+import { hasSuccessfulWriteToolPart } from "@/lib/ai/write-tools";
+
+import { hasPendingApprovalRequest } from "./utils";
 
 function buildClientFileValidationError(
   fileParts: FileUIPart[],
@@ -319,7 +321,7 @@ export function Chat({
 
       setChatErrorMessage(null);
       // Approved writes changed portfolio data: re-pull the RSC dashboard.
-      if (messageHasSuccessfulWrite(message)) {
+      if (hasSuccessfulWriteToolPart(message.parts)) {
         router.refresh();
       }
       await onConversationPersisted?.();

--- a/components/dashboard/ai-chat/chat.tsx
+++ b/components/dashboard/ai-chat/chat.tsx
@@ -330,7 +330,7 @@ export function Chat({
     setMessages(initialMessages);
   }, [initialMessages, setMessages]);
 
-  const hasPendingApproval = hasPendingApprovalRequest(messages);
+  const hasPendingApproval = hasPendingApprovalRequest(messages, status);
   const showProactiveCapAlert =
     Boolean(isAIEnabled) &&
     Boolean(isAtConversationCap) &&

--- a/components/dashboard/ai-chat/chat.tsx
+++ b/components/dashboard/ai-chat/chat.tsx
@@ -454,6 +454,7 @@ export function Chat({
               messages={messages}
               status={status}
               isAIEnabled={isAIEnabled}
+              hasPendingApproval={hasPendingApproval}
               copiedMessages={copiedMessages}
               onCopy={handleCopy}
               onRegenerate={regenerate}

--- a/components/dashboard/ai-chat/chat.tsx
+++ b/components/dashboard/ai-chat/chat.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { DefaultChatTransport, type FileUIPart } from "ai";
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+  type FileUIPart,
+} from "ai";
+import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState, useEffect } from "react";
 
 import {
@@ -35,6 +40,7 @@ import { DisabledState } from "./disabled-state";
 import { ChatSuggestions } from "./suggestions";
 import { ChatThread } from "./thread";
 import type { ChatProps } from "./types";
+import { hasPendingApprovalRequest, messageHasSuccessfulWrite } from "./utils";
 
 function buildClientFileValidationError(
   fileParts: FileUIPart[],
@@ -143,6 +149,7 @@ export function Chat({
   const hasSyncedDraftInputRef = useRef(false);
   const hasSyncedDraftFilesRef = useRef(false);
 
+  const router = useRouter();
   const { copyToClipboard } = useCopyToClipboard({ timeout: 4000 });
   const controller = usePromptInputController();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -285,31 +292,45 @@ export function Chat({
     });
   }, [mode, conversationId]);
 
-  const { messages, setMessages, sendMessage, status, stop, regenerate } =
-    useChat({
-      id: conversationId,
-      messages: initialMessages,
-      transport,
-      onError: (error) => {
-        // Normalize backend cap error into a stable, user-friendly message.
-        const message = isConversationCapErrorMessage(error.message)
-          ? AI_CHAT_CONVERSATION_CAP_FRIENDLY_MESSAGE
-          : error.message;
+  const {
+    messages,
+    setMessages,
+    sendMessage,
+    status,
+    stop,
+    regenerate,
+    addToolApprovalResponse,
+  } = useChat({
+    id: conversationId,
+    messages: initialMessages,
+    transport,
+    // Resume the turn automatically once every approval request is answered.
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+    onError: (error) => {
+      // Normalize backend cap error into a stable, user-friendly message.
+      const message = isConversationCapErrorMessage(error.message)
+        ? AI_CHAT_CONVERSATION_CAP_FRIENDLY_MESSAGE
+        : error.message;
 
-        setChatErrorMessage(message);
-      },
-      onFinish: async ({ isAbort, isError }) => {
-        if (isAbort || isError) return;
+      setChatErrorMessage(message);
+    },
+    onFinish: async ({ message, isAbort, isError }) => {
+      if (isAbort || isError) return;
 
-        setChatErrorMessage(null);
-        await onConversationPersisted?.();
-      },
-    });
+      setChatErrorMessage(null);
+      // Approved writes changed portfolio data: re-pull the RSC dashboard.
+      if (messageHasSuccessfulWrite(message)) {
+        router.refresh();
+      }
+      await onConversationPersisted?.();
+    },
+  });
 
   useEffect(() => {
     setMessages(initialMessages);
   }, [initialMessages, setMessages]);
 
+  const hasPendingApproval = hasPendingApprovalRequest(messages);
   const showProactiveCapAlert =
     Boolean(isAIEnabled) &&
     Boolean(isAtConversationCap) &&
@@ -321,10 +342,20 @@ export function Chat({
 
   // Quick-send a suggested prompt
   const handleSuggestionClick = (suggestion: string) => {
-    if (showProactiveCapAlert) return;
+    if (showProactiveCapAlert || hasPendingApproval) return;
 
     setChatErrorMessage(null);
     sendMessage({ text: suggestion }, { body: { promptSource: "suggestion" } });
+  };
+
+  // Answer a write-tool approval request; auto-resend continues the turn.
+  const handleApprovalResponse = (approvalId: string, isApproved: boolean) => {
+    setChatErrorMessage(null);
+    addToolApprovalResponse({
+      id: approvalId,
+      approved: isApproved,
+      reason: isApproved ? undefined : "User denied this action.",
+    });
   };
 
   // Copy message text with a temporary visual state
@@ -342,7 +373,7 @@ export function Chat({
 
   // Submit user input to the chat
   const handleSubmit = (message: PromptInputMessage) => {
-    if (showProactiveCapAlert) {
+    if (showProactiveCapAlert || hasPendingApproval) {
       return;
     }
 
@@ -426,6 +457,7 @@ export function Chat({
               copiedMessages={copiedMessages}
               onCopy={handleCopy}
               onRegenerate={regenerate}
+              onApprovalResponse={handleApprovalResponse}
             />
           )}
         </ConversationContent>
@@ -451,6 +483,7 @@ export function Chat({
         mode={mode}
         isAIEnabled={isAIEnabled}
         showProactiveCapAlert={showProactiveCapAlert}
+        hasPendingApproval={hasPendingApproval}
         controller={controller}
         textareaRef={textareaRef}
         onSubmit={handleSubmit}

--- a/components/dashboard/ai-chat/composer.tsx
+++ b/components/dashboard/ai-chat/composer.tsx
@@ -63,6 +63,7 @@ export function ChatComposer({
   mode,
   isAIEnabled,
   showProactiveCapAlert,
+  hasPendingApproval,
   controller,
   textareaRef,
   onSubmit,
@@ -95,7 +96,11 @@ export function ChatComposer({
 
         <PromptInputBody>
           <PromptInputTextarea
-            placeholder="Ask Foliofox..."
+            placeholder={
+              hasPendingApproval
+                ? "Approve or deny the proposed action to continue"
+                : "Ask Foliofox..."
+            }
             ref={textareaRef}
           />
         </PromptInputBody>
@@ -143,7 +148,7 @@ export function ChatComposer({
           <PromptInputSubmit
             status={status}
             disabled={
-              isChatInputDisabled
+              isChatInputDisabled || hasPendingApproval
                 ? true
                 : status === "streaming"
                   ? false

--- a/components/dashboard/ai-chat/message.tsx
+++ b/components/dashboard/ai-chat/message.tsx
@@ -26,6 +26,15 @@ import {
   SourcesTrigger,
 } from "@/components/ai-elements/sources";
 import {
+  Confirmation,
+  ConfirmationAccepted,
+  ConfirmationAction,
+  ConfirmationActions,
+  ConfirmationRejected,
+  ConfirmationRequest,
+  ConfirmationTitle,
+} from "@/components/ai-elements/confirmation";
+import {
   Tool,
   ToolContent,
   ToolHeader,
@@ -39,6 +48,7 @@ import {
   getSourceLabel,
   isMessageFilePart,
   isMessageSourcePart,
+  isWriteToolPartType,
 } from "./utils";
 import { getToolOutputPreview } from "./tool-output-preview";
 
@@ -50,6 +60,7 @@ export function ChatMessage({
   isCopied,
   onCopy,
   onRegenerate,
+  onApprovalResponse,
 }: ChatMessageProps) {
   const isAssistant = message.role === "assistant";
   const isStreaming = status === "streaming";
@@ -179,25 +190,73 @@ export function ChatMessage({
             return null;
           default:
             if (isStaticToolUIPart(part)) {
+              const approval = "approval" in part ? part.approval : undefined;
+              const toolInput = part.input as
+                { summary?: unknown } | null | undefined;
+              const approvalSummary =
+                typeof toolInput?.summary === "string" &&
+                toolInput.summary.trim()
+                  ? toolInput.summary
+                  : "The advisor proposes a portfolio change.";
+
               return (
-                <Tool
-                  key={`${message.id}-part-${index}`}
-                  className="notranslate mb-0"
-                  translate="no"
-                >
-                  <ToolHeader
-                    type={part.type}
-                    state={part.state}
-                    className="truncate"
-                  />
-                  <ToolContent>
-                    <ToolInput input={part.input} />
-                    <ToolOutput
-                      output={getToolOutputPreview(part)}
-                      errorText={part.errorText}
+                <Fragment key={`${message.id}-part-${index}`}>
+                  <Tool className="notranslate mb-0" translate="no">
+                    <ToolHeader
+                      type={part.type}
+                      state={part.state}
+                      className="truncate"
                     />
-                  </ToolContent>
-                </Tool>
+                    <ToolContent>
+                      <ToolInput input={part.input} />
+                      <ToolOutput
+                        output={getToolOutputPreview(part)}
+                        errorText={part.errorText}
+                      />
+                    </ToolContent>
+                  </Tool>
+                  {isWriteToolPartType(part.type) && approval && (
+                    <Confirmation
+                      className="notranslate"
+                      translate="no"
+                      state={part.state}
+                      approval={approval}
+                    >
+                      <ConfirmationTitle className="text-foreground">
+                        {approvalSummary}
+                      </ConfirmationTitle>
+                      <ConfirmationRequest>
+                        <ConfirmationActions>
+                          <ConfirmationAction
+                            variant="outline"
+                            onClick={() =>
+                              onApprovalResponse(approval.id, false)
+                            }
+                          >
+                            Deny
+                          </ConfirmationAction>
+                          <ConfirmationAction
+                            onClick={() =>
+                              onApprovalResponse(approval.id, true)
+                            }
+                          >
+                            Approve
+                          </ConfirmationAction>
+                        </ConfirmationActions>
+                      </ConfirmationRequest>
+                      <ConfirmationAccepted>
+                        <p className="text-muted-foreground text-xs">
+                          You approved this action.
+                        </p>
+                      </ConfirmationAccepted>
+                      <ConfirmationRejected>
+                        <p className="text-muted-foreground text-xs">
+                          You denied this action.
+                        </p>
+                      </ConfirmationRejected>
+                    </Confirmation>
+                  )}
+                </Fragment>
               );
             }
 

--- a/components/dashboard/ai-chat/message.tsx
+++ b/components/dashboard/ai-chat/message.tsx
@@ -43,12 +43,13 @@ import {
 } from "@/components/ai-elements/tool";
 import { cn } from "@/lib/utils";
 
+import { isWriteToolPartType } from "@/lib/ai/write-tools";
+
 import type { ChatMessageProps } from "./types";
 import {
   getSourceLabel,
   isMessageFilePart,
   isMessageSourcePart,
-  isWriteToolPartType,
 } from "./utils";
 import { getToolOutputPreview } from "./tool-output-preview";
 

--- a/components/dashboard/ai-chat/message.tsx
+++ b/components/dashboard/ai-chat/message.tsx
@@ -228,7 +228,7 @@ export function ChatMessage({
                       state={part.state}
                       approval={approval}
                     >
-                      <ConfirmationTitle className="text-foreground">
+                      <ConfirmationTitle className="text-foreground font-medium">
                         {approvalSummary}
                       </ConfirmationTitle>
                       <ConfirmationRequest>

--- a/components/dashboard/ai-chat/message.tsx
+++ b/components/dashboard/ai-chat/message.tsx
@@ -57,6 +57,7 @@ export function ChatMessage({
   isLastMessage,
   status,
   isAIEnabled,
+  hasPendingApproval,
   isCopied,
   onCopy,
   onRegenerate,
@@ -165,7 +166,7 @@ export function ChatMessage({
                       <MessageAction
                         onClick={() => onRegenerate()}
                         tooltip="Regenerate response"
-                        disabled={!isAIEnabled}
+                        disabled={!isAIEnabled || hasPendingApproval}
                       >
                         <RefreshCcw className="size-3.5" />
                       </MessageAction>
@@ -198,6 +199,11 @@ export function ChatMessage({
                 toolInput.summary.trim()
                   ? toolInput.summary
                   : "The advisor proposes a portfolio change.";
+              // The summary is model-written prose; show the executable args
+              // too so the user approves what will actually run.
+              const approvalDetails = Object.entries(
+                (toolInput ?? {}) as Record<string, unknown>,
+              ).filter(([key, value]) => key !== "summary" && value != null);
 
               return (
                 <Fragment key={`${message.id}-part-${index}`}>
@@ -226,6 +232,18 @@ export function ChatMessage({
                         {approvalSummary}
                       </ConfirmationTitle>
                       <ConfirmationRequest>
+                        {approvalDetails.length > 0 && (
+                          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+                            {approvalDetails.map(([key, value]) => (
+                              <Fragment key={key}>
+                                <dt className="text-muted-foreground">{key}</dt>
+                                <dd className="font-medium break-all">
+                                  {String(value)}
+                                </dd>
+                              </Fragment>
+                            ))}
+                          </dl>
+                        )}
                         <ConfirmationActions>
                           <ConfirmationAction
                             variant="outline"

--- a/components/dashboard/ai-chat/thread.tsx
+++ b/components/dashboard/ai-chat/thread.tsx
@@ -10,6 +10,7 @@ export function ChatThread({
   copiedMessages,
   onCopy,
   onRegenerate,
+  onApprovalResponse,
 }: ChatThreadProps) {
   return (
     <>
@@ -23,6 +24,7 @@ export function ChatThread({
           isCopied={copiedMessages.has(message.id)}
           onCopy={onCopy}
           onRegenerate={onRegenerate}
+          onApprovalResponse={onApprovalResponse}
         />
       ))}
       {status === "submitted" && <MessageLoading />}

--- a/components/dashboard/ai-chat/thread.tsx
+++ b/components/dashboard/ai-chat/thread.tsx
@@ -7,6 +7,7 @@ export function ChatThread({
   messages,
   status,
   isAIEnabled,
+  hasPendingApproval,
   copiedMessages,
   onCopy,
   onRegenerate,
@@ -21,6 +22,7 @@ export function ChatThread({
           isLastMessage={messageIndex === messages.length - 1}
           status={status}
           isAIEnabled={isAIEnabled}
+          hasPendingApproval={hasPendingApproval}
           isCopied={copiedMessages.has(message.id)}
           onCopy={onCopy}
           onRegenerate={onRegenerate}

--- a/components/dashboard/ai-chat/types.ts
+++ b/components/dashboard/ai-chat/types.ts
@@ -28,6 +28,7 @@ export interface ChatThreadProps {
   messages: UIMessage[];
   status: ChatStatus;
   isAIEnabled?: boolean;
+  hasPendingApproval: boolean;
   copiedMessages: Set<string>;
   onCopy: (text: string, messageId: string) => void;
   onRegenerate: () => void;
@@ -39,6 +40,7 @@ export interface ChatMessageProps {
   isLastMessage: boolean;
   status: ChatStatus;
   isAIEnabled?: boolean;
+  hasPendingApproval: boolean;
   isCopied: boolean;
   onCopy: (text: string, messageId: string) => void;
   onRegenerate: () => void;

--- a/components/dashboard/ai-chat/types.ts
+++ b/components/dashboard/ai-chat/types.ts
@@ -31,6 +31,7 @@ export interface ChatThreadProps {
   copiedMessages: Set<string>;
   onCopy: (text: string, messageId: string) => void;
   onRegenerate: () => void;
+  onApprovalResponse: (approvalId: string, isApproved: boolean) => void;
 }
 
 export interface ChatMessageProps {
@@ -41,6 +42,7 @@ export interface ChatMessageProps {
   isCopied: boolean;
   onCopy: (text: string, messageId: string) => void;
   onRegenerate: () => void;
+  onApprovalResponse: (approvalId: string, isApproved: boolean) => void;
 }
 
 export interface ChatComposerProps {
@@ -48,6 +50,7 @@ export interface ChatComposerProps {
   mode: Mode;
   isAIEnabled?: boolean;
   showProactiveCapAlert: boolean;
+  hasPendingApproval: boolean;
   controller: PromptInputControllerProps;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   onSubmit: (message: PromptInputMessage) => void;

--- a/components/dashboard/ai-chat/utils.test.ts
+++ b/components/dashboard/ai-chat/utils.test.ts
@@ -2,12 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { UIMessage } from "ai";
 
-import {
-  generateUuid,
-  hasPendingApprovalRequest,
-  isWriteToolPartType,
-  messageHasSuccessfulWrite,
-} from "./utils";
+import { generateUuid, hasPendingApprovalRequest } from "./utils";
 
 const UUID_V4_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -47,14 +42,7 @@ function assistantMessage(parts: unknown[]): UIMessage {
   } as UIMessage;
 }
 
-describe("write tool helpers", () => {
-  it("identifies only the write tool part types", () => {
-    expect(isWriteToolPartType("tool-createPortfolioRecord")).toBe(true);
-    expect(isWriteToolPartType("tool-createPosition")).toBe(true);
-    expect(isWriteToolPartType("tool-getPortfolioOverview")).toBe(false);
-    expect(isWriteToolPartType("text")).toBe(false);
-  });
-
+describe("pending approval detection", () => {
   it("detects a pending approval on the last assistant message", () => {
     const messages = [
       assistantMessage([
@@ -170,59 +158,5 @@ describe("write tool helpers", () => {
     ).toBe(false);
 
     expect(hasPendingApprovalRequest([], "ready")).toBe(false);
-  });
-
-  it("detects successful writes and ignores failed or read tool outputs", () => {
-    expect(
-      messageHasSuccessfulWrite(
-        assistantMessage([
-          {
-            type: "tool-createPosition",
-            state: "output-available",
-            input: { summary: "Add" },
-            output: { success: true },
-          },
-        ]),
-      ),
-    ).toBe(true);
-
-    expect(
-      messageHasSuccessfulWrite(
-        assistantMessage([
-          {
-            type: "tool-createPosition",
-            state: "output-available",
-            input: { summary: "Add" },
-            output: { success: false, code: "DUPLICATE_NAME" },
-          },
-        ]),
-      ),
-    ).toBe(false);
-
-    expect(
-      messageHasSuccessfulWrite(
-        assistantMessage([
-          {
-            type: "tool-getPortfolioOverview",
-            state: "output-available",
-            input: {},
-            output: { success: true },
-          },
-        ]),
-      ),
-    ).toBe(false);
-
-    expect(
-      messageHasSuccessfulWrite(
-        assistantMessage([
-          {
-            type: "tool-createPortfolioRecord",
-            state: "output-denied",
-            input: { summary: "Buy" },
-            approval: { id: "approval-1", approved: false },
-          },
-        ]),
-      ),
-    ).toBe(false);
   });
 });

--- a/components/dashboard/ai-chat/utils.test.ts
+++ b/components/dashboard/ai-chat/utils.test.ts
@@ -70,7 +70,24 @@ describe("write tool helpers", () => {
     expect(hasPendingApprovalRequest(messages)).toBe(true);
   });
 
-  it("reports no pending approval once responded or on non-assistant last message", () => {
+  it("still counts approval-responded as pending until the turn resumes", () => {
+    // addToolApprovalResponse flips the part synchronously, but the auto
+    // resend is async — sends must stay blocked in that gap.
+    expect(
+      hasPendingApprovalRequest([
+        assistantMessage([
+          {
+            type: "tool-createPortfolioRecord",
+            state: "approval-responded",
+            input: { summary: "Buy" },
+            approval: { id: "approval-1", approved: true },
+          },
+        ]),
+      ]),
+    ).toBe(true);
+  });
+
+  it("reports no pending approval once resolved or on non-assistant last message", () => {
     expect(
       hasPendingApprovalRequest([
         assistantMessage([
@@ -80,6 +97,19 @@ describe("write tool helpers", () => {
             input: { summary: "Buy" },
             output: { success: true },
             approval: { id: "approval-1", approved: true },
+          },
+        ]),
+      ]),
+    ).toBe(false);
+
+    expect(
+      hasPendingApprovalRequest([
+        assistantMessage([
+          {
+            type: "tool-createPortfolioRecord",
+            state: "output-denied",
+            input: { summary: "Buy" },
+            approval: { id: "approval-1", approved: false },
           },
         ]),
       ]),

--- a/components/dashboard/ai-chat/utils.test.ts
+++ b/components/dashboard/ai-chat/utils.test.ts
@@ -67,61 +67,109 @@ describe("write tool helpers", () => {
       ]),
     ];
 
-    expect(hasPendingApprovalRequest(messages)).toBe(true);
+    expect(hasPendingApprovalRequest(messages, "ready")).toBe(true);
   });
 
   it("still counts approval-responded as pending until the turn resumes", () => {
     // addToolApprovalResponse flips the part synchronously, but the auto
     // resend is async — sends must stay blocked in that gap.
     expect(
-      hasPendingApprovalRequest([
-        assistantMessage([
-          {
-            type: "tool-createPortfolioRecord",
-            state: "approval-responded",
-            input: { summary: "Buy" },
-            approval: { id: "approval-1", approved: true },
-          },
-        ]),
-      ]),
+      hasPendingApprovalRequest(
+        [
+          assistantMessage([
+            {
+              type: "tool-createPortfolioRecord",
+              state: "approval-responded",
+              input: { summary: "Buy" },
+              approval: { id: "approval-1", approved: true },
+            },
+          ]),
+        ],
+        "ready",
+      ),
+    ).toBe(true);
+  });
+
+  it("unblocks a stranded approval-responded part when the chat errored", () => {
+    // A failed continuation request would otherwise leave the session stuck
+    // (no buttons, sends blocked) until a full page reload.
+    expect(
+      hasPendingApprovalRequest(
+        [
+          assistantMessage([
+            {
+              type: "tool-createPortfolioRecord",
+              state: "approval-responded",
+              input: { summary: "Buy" },
+              approval: { id: "approval-1", approved: true },
+            },
+          ]),
+        ],
+        "error",
+      ),
+    ).toBe(false);
+
+    // An unanswered request keeps blocking even on error: the card still
+    // shows Approve/Deny, so answering it remains the way forward.
+    expect(
+      hasPendingApprovalRequest(
+        [
+          assistantMessage([
+            {
+              type: "tool-createPortfolioRecord",
+              state: "approval-requested",
+              input: { summary: "Buy" },
+              approval: { id: "approval-1" },
+            },
+          ]),
+        ],
+        "error",
+      ),
     ).toBe(true);
   });
 
   it("reports no pending approval once resolved or on non-assistant last message", () => {
     expect(
-      hasPendingApprovalRequest([
-        assistantMessage([
-          {
-            type: "tool-createPortfolioRecord",
-            state: "output-available",
-            input: { summary: "Buy" },
-            output: { success: true },
-            approval: { id: "approval-1", approved: true },
-          },
-        ]),
-      ]),
+      hasPendingApprovalRequest(
+        [
+          assistantMessage([
+            {
+              type: "tool-createPortfolioRecord",
+              state: "output-available",
+              input: { summary: "Buy" },
+              output: { success: true },
+              approval: { id: "approval-1", approved: true },
+            },
+          ]),
+        ],
+        "ready",
+      ),
     ).toBe(false);
 
     expect(
-      hasPendingApprovalRequest([
-        assistantMessage([
-          {
-            type: "tool-createPortfolioRecord",
-            state: "output-denied",
-            input: { summary: "Buy" },
-            approval: { id: "approval-1", approved: false },
-          },
-        ]),
-      ]),
+      hasPendingApprovalRequest(
+        [
+          assistantMessage([
+            {
+              type: "tool-createPortfolioRecord",
+              state: "output-denied",
+              input: { summary: "Buy" },
+              approval: { id: "approval-1", approved: false },
+            },
+          ]),
+        ],
+        "ready",
+      ),
     ).toBe(false);
 
     expect(
-      hasPendingApprovalRequest([
-        { id: "user-1", role: "user", parts: [] } as unknown as UIMessage,
-      ]),
+      hasPendingApprovalRequest(
+        [{ id: "user-1", role: "user", parts: [] } as unknown as UIMessage],
+        "ready",
+      ),
     ).toBe(false);
 
-    expect(hasPendingApprovalRequest([])).toBe(false);
+    expect(hasPendingApprovalRequest([], "ready")).toBe(false);
   });
 
   it("detects successful writes and ignores failed or read tool outputs", () => {

--- a/components/dashboard/ai-chat/utils.test.ts
+++ b/components/dashboard/ai-chat/utils.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { generateUuid } from "./utils";
+import type { UIMessage } from "ai";
+
+import {
+  generateUuid,
+  hasPendingApprovalRequest,
+  isWriteToolPartType,
+  messageHasSuccessfulWrite,
+} from "./utils";
 
 const UUID_V4_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -29,5 +36,115 @@ describe("generateUuid", () => {
 
     expect(generateUuid()).toMatch(UUID_V4_PATTERN);
     expect(generateUuid()).not.toBe(generateUuid());
+  });
+});
+
+function assistantMessage(parts: unknown[]): UIMessage {
+  return {
+    id: "assistant-1",
+    role: "assistant",
+    parts,
+  } as UIMessage;
+}
+
+describe("write tool helpers", () => {
+  it("identifies only the write tool part types", () => {
+    expect(isWriteToolPartType("tool-createPortfolioRecord")).toBe(true);
+    expect(isWriteToolPartType("tool-createPosition")).toBe(true);
+    expect(isWriteToolPartType("tool-getPortfolioOverview")).toBe(false);
+    expect(isWriteToolPartType("text")).toBe(false);
+  });
+
+  it("detects a pending approval on the last assistant message", () => {
+    const messages = [
+      assistantMessage([
+        {
+          type: "tool-createPortfolioRecord",
+          state: "approval-requested",
+          input: { summary: "Buy" },
+          approval: { id: "approval-1" },
+        },
+      ]),
+    ];
+
+    expect(hasPendingApprovalRequest(messages)).toBe(true);
+  });
+
+  it("reports no pending approval once responded or on non-assistant last message", () => {
+    expect(
+      hasPendingApprovalRequest([
+        assistantMessage([
+          {
+            type: "tool-createPortfolioRecord",
+            state: "output-available",
+            input: { summary: "Buy" },
+            output: { success: true },
+            approval: { id: "approval-1", approved: true },
+          },
+        ]),
+      ]),
+    ).toBe(false);
+
+    expect(
+      hasPendingApprovalRequest([
+        { id: "user-1", role: "user", parts: [] } as unknown as UIMessage,
+      ]),
+    ).toBe(false);
+
+    expect(hasPendingApprovalRequest([])).toBe(false);
+  });
+
+  it("detects successful writes and ignores failed or read tool outputs", () => {
+    expect(
+      messageHasSuccessfulWrite(
+        assistantMessage([
+          {
+            type: "tool-createPosition",
+            state: "output-available",
+            input: { summary: "Add" },
+            output: { success: true },
+          },
+        ]),
+      ),
+    ).toBe(true);
+
+    expect(
+      messageHasSuccessfulWrite(
+        assistantMessage([
+          {
+            type: "tool-createPosition",
+            state: "output-available",
+            input: { summary: "Add" },
+            output: { success: false, code: "DUPLICATE_NAME" },
+          },
+        ]),
+      ),
+    ).toBe(false);
+
+    expect(
+      messageHasSuccessfulWrite(
+        assistantMessage([
+          {
+            type: "tool-getPortfolioOverview",
+            state: "output-available",
+            input: {},
+            output: { success: true },
+          },
+        ]),
+      ),
+    ).toBe(false);
+
+    expect(
+      messageHasSuccessfulWrite(
+        assistantMessage([
+          {
+            type: "tool-createPortfolioRecord",
+            state: "output-denied",
+            input: { summary: "Buy" },
+            approval: { id: "approval-1", approved: false },
+          },
+        ]),
+      ),
+    ).toBe(false);
   });
 });

--- a/components/dashboard/ai-chat/utils.ts
+++ b/components/dashboard/ai-chat/utils.ts
@@ -2,16 +2,6 @@ import { isStaticToolUIPart, type ChatStatus, type UIMessage } from "ai";
 
 import type { MessageFilePart, MessageSourcePart } from "./types";
 
-// Approval-gated write tools rendered with a Confirmation card.
-const WRITE_TOOL_PART_TYPES = new Set([
-  "tool-createPortfolioRecord",
-  "tool-createPosition",
-]);
-
-export function isWriteToolPartType(partType: string): boolean {
-  return WRITE_TOOL_PART_TYPES.has(partType);
-}
-
 /**
  * A pending approval blocks new sends: an unanswered approval request would
  * leave a dangling tool call and break the next model request.
@@ -37,27 +27,6 @@ export function hasPendingApprovalRequest(
       (part.state === "approval-requested" ||
         (part.state === "approval-responded" && status !== "error")),
   );
-}
-
-/**
- * True when the message contains a write tool that executed successfully,
- * meaning dashboard data (RSC) is stale and should be refreshed.
- */
-export function messageHasSuccessfulWrite(message: UIMessage): boolean {
-  return message.parts.some((part) => {
-    if (!isStaticToolUIPart(part)) {
-      return false;
-    }
-    if (!isWriteToolPartType(part.type)) {
-      return false;
-    }
-    if (part.state !== "output-available") {
-      return false;
-    }
-
-    const output = part.output as { success?: unknown } | null | undefined;
-    return output != null && output.success === true;
-  });
 }
 
 /**

--- a/components/dashboard/ai-chat/utils.ts
+++ b/components/dashboard/ai-chat/utils.ts
@@ -1,4 +1,4 @@
-import { isStaticToolUIPart, type UIMessage } from "ai";
+import { isStaticToolUIPart, type ChatStatus, type UIMessage } from "ai";
 
 import type { MessageFilePart, MessageSourcePart } from "./types";
 
@@ -17,9 +17,15 @@ export function isWriteToolPartType(partType: string): boolean {
  * leave a dangling tool call and break the next model request.
  * "approval-responded" is still pending — the SDK flips the part state
  * synchronously but schedules the auto-resend async, so until the request
- * actually starts the turn is not resolved yet.
+ * actually starts the turn is not resolved yet. If that continuation request
+ * errors the part stays "approval-responded" forever, so stop blocking on
+ * chat error to keep regenerate/submit available as recovery (a resend still
+ * carries the approval response, so the approved write is not lost).
  */
-export function hasPendingApprovalRequest(messages: UIMessage[]): boolean {
+export function hasPendingApprovalRequest(
+  messages: UIMessage[],
+  status: ChatStatus,
+): boolean {
   const lastMessage = messages.at(-1);
   if (lastMessage?.role !== "assistant") {
     return false;
@@ -29,7 +35,7 @@ export function hasPendingApprovalRequest(messages: UIMessage[]): boolean {
     (part) =>
       isStaticToolUIPart(part) &&
       (part.state === "approval-requested" ||
-        part.state === "approval-responded"),
+        (part.state === "approval-responded" && status !== "error")),
   );
 }
 

--- a/components/dashboard/ai-chat/utils.ts
+++ b/components/dashboard/ai-chat/utils.ts
@@ -1,6 +1,52 @@
-import type { UIMessage } from "ai";
+import { isStaticToolUIPart, type UIMessage } from "ai";
 
 import type { MessageFilePart, MessageSourcePart } from "./types";
+
+// Approval-gated write tools rendered with a Confirmation card.
+const WRITE_TOOL_PART_TYPES = new Set([
+  "tool-createPortfolioRecord",
+  "tool-createPosition",
+]);
+
+export function isWriteToolPartType(partType: string): boolean {
+  return WRITE_TOOL_PART_TYPES.has(partType);
+}
+
+/**
+ * A pending approval blocks new sends: an unanswered approval request would
+ * leave a dangling tool call and break the next model request.
+ */
+export function hasPendingApprovalRequest(messages: UIMessage[]): boolean {
+  const lastMessage = messages.at(-1);
+  if (lastMessage?.role !== "assistant") {
+    return false;
+  }
+
+  return lastMessage.parts.some(
+    (part) => isStaticToolUIPart(part) && part.state === "approval-requested",
+  );
+}
+
+/**
+ * True when the message contains a write tool that executed successfully,
+ * meaning dashboard data (RSC) is stale and should be refreshed.
+ */
+export function messageHasSuccessfulWrite(message: UIMessage): boolean {
+  return message.parts.some((part) => {
+    if (!isStaticToolUIPart(part)) {
+      return false;
+    }
+    if (!isWriteToolPartType(part.type)) {
+      return false;
+    }
+    if (part.state !== "output-available") {
+      return false;
+    }
+
+    const output = part.output as { success?: unknown } | null | undefined;
+    return output != null && output.success === true;
+  });
+}
 
 /**
  * Generate a v4 UUID in the browser.

--- a/components/dashboard/ai-chat/utils.ts
+++ b/components/dashboard/ai-chat/utils.ts
@@ -15,6 +15,9 @@ export function isWriteToolPartType(partType: string): boolean {
 /**
  * A pending approval blocks new sends: an unanswered approval request would
  * leave a dangling tool call and break the next model request.
+ * "approval-responded" is still pending — the SDK flips the part state
+ * synchronously but schedules the auto-resend async, so until the request
+ * actually starts the turn is not resolved yet.
  */
 export function hasPendingApprovalRequest(messages: UIMessage[]): boolean {
   const lastMessage = messages.at(-1);
@@ -23,7 +26,10 @@ export function hasPendingApprovalRequest(messages: UIMessage[]): boolean {
   }
 
   return lastMessage.parts.some(
-    (part) => isStaticToolUIPart(part) && part.state === "approval-requested",
+    (part) =>
+      isStaticToolUIPart(part) &&
+      (part.state === "approval-requested" ||
+        part.state === "approval-responded"),
   );
 }
 

--- a/components/dashboard/portfolio-records/market-backed-update-warning.test.tsx
+++ b/components/dashboard/portfolio-records/market-backed-update-warning.test.tsx
@@ -137,6 +137,7 @@ function createPositionFixture(
     description: null,
     archived_at: null,
     capital_gains_tax_rate: null,
+    idempotency_key: null,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",
     is_archived: false,

--- a/components/dashboard/portfolio-records/market-backed-update-warning.test.tsx
+++ b/components/dashboard/portfolio-records/market-backed-update-warning.test.tsx
@@ -169,6 +169,7 @@ function createPortfolioRecordFixture(
     description: null,
     import_source: null,
     external_transaction_id: null,
+    idempotency_key: null,
     created_at: "2026-01-02T00:00:00.000Z",
     updated_at: "2026-01-02T00:00:00.000Z",
     positions: {

--- a/components/dashboard/positions/asset/header.test.tsx
+++ b/components/dashboard/positions/asset/header.test.tsx
@@ -38,6 +38,7 @@ function createPosition(): TransformedPosition {
     currency: "USD",
     category_id: "stocks",
     capital_gains_tax_rate: null,
+    idempotency_key: null,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",
     archived_at: null,

--- a/components/dashboard/positions/asset/update/form.test.tsx
+++ b/components/dashboard/positions/asset/update/form.test.tsx
@@ -32,6 +32,7 @@ function createPosition(): Position {
     category_id: "equity",
     user_category_id: null,
     capital_gains_tax_rate: null,
+    idempotency_key: null,
     description: null,
     symbol_id: null,
     currency: "EUR",

--- a/content/product-reference.md
+++ b/content/product-reference.md
@@ -12,6 +12,8 @@
   - components/dashboard/new-asset/forms/ (add-asset paths + field rules)
   - components/dashboard/new-portfolio-record/forms/ (buy/sell/update rules)
   - server/portfolio-records/create.ts (record semantics + snapshot recalculation)
+  - server/ai/tools/create-portfolio-record.ts, server/ai/tools/create-position.ts (AI advisor write tools)
+  - app/api/ai/chat/route.ts (AI write-tool approval gating)
   - lib/capital-gains-tax-rate.ts (tax rate input semantics)
   - types/database.types.ts Constants.public.Enums
   - VISION.md, README.md, AGENTS.md
@@ -69,6 +71,17 @@ Three ways to add an asset:
 | `update` | A revaluation checkpoint: sets the position's quantity and unit value as of a date | Quantity and unit value must be ≥ 0; optionally resets cost basis per unit |
 
 Buys and sells adjust quantity incrementally and feed cost basis. An `update` overrides the running state — useful for interest accrual on cash, revaluing property, or correcting drift. Record dates use `YYYY-MM-DD` format. After any record change, snapshots recalculate from the record's date until the next `update` record.
+
+## AI advisor portfolio updates
+
+The AI advisor can update the portfolio on your behalf, in any of its three modes:
+
+- **Record a buy, sell, or update** on an existing position (e.g. "I bought 20 AAPL at 211.50 today, sync my portfolio").
+- **Add a new position** (asset or future liability), including symbol-linked assets priced automatically.
+
+Every proposed change shows an approval card in the chat with a plain-language summary of exactly what will happen. **Nothing is written until you press Approve** — denying the change discards it, and the advisor will ask what to adjust instead of retrying. While an approval is pending, the message box is blocked until you approve or deny.
+
+Approved changes go through the same validation as the regular forms (record timeline checks, oversell protection, duplicate names, snapshot recalculation), and the dashboard refreshes right after a successful change. The advisor cannot delete or archive positions, edit or delete existing records, or run imports — use the dashboard for those.
 
 ## CSV import — positions
 

--- a/docs/ai/AI-ADVISOR-ROADMAP.md
+++ b/docs/ai/AI-ADVISOR-ROADMAP.md
@@ -191,9 +191,15 @@ Objective: transform frequent goal/probability/rebalance questions into actionab
 
 ---
 
-## Phase 4: Controlled Portfolio Writes (Approval-Gated Tools)
+## Phase 4: Controlled Portfolio Writes (Approval-Gated Tools) — SHIPPED
 
 Objective: let users update portfolio data directly from chat with explicit approval and strong safety checks.
+
+> **Design note (v2):** the original draft/commit 4-tool protocol below was designed
+> against AI SDK 5, before native tool approvals existed. The shipped implementation
+> uses AI SDK v7 `toolApproval: 'user-approval'` on `streamText`: the SDK approval
+> round-trip **is** the draft → summary → approve → execute flow, so each write needs
+> exactly one tool.
 
 ### Why This Phase
 
@@ -201,53 +207,55 @@ Objective: let users update portfolio data directly from chat with explicit appr
 - Current advisor is mostly read/analyze oriented; this phase closes the loop from advice to execution inside Foliofox.
 - UI already includes tool states for approval/denial, so we can build on an aligned interaction model.
 
-### Workstream A: Write Tool Surface (Records First)
+### Workstream A: Write Tool Surface — DONE
 
-- Add approval-gated tools for portfolio records:
-  - `draftCreatePortfolioRecord`
-  - `commitCreatePortfolioRecord`
-  - `draftUpdatePortfolioRecord`
-  - `commitUpdatePortfolioRecord`
-- Start with records (`buy`, `sell`, `update`) before direct position mutations to reduce blast radius.
-- Keep inputs explicit and typed: `position_id`, `type`, `date`, `quantity`, `unit_value`, optional `description`.
+- `createPortfolioRecord` (buy/sell/update on existing positions) and `createPosition`
+  (new asset/liability), thin wrappers over the shared form/import mutations
+  (`server/portfolio-records/create.ts`, `server/positions/create.ts`).
+- Companion read tool `getPositionCategories` so the model picks valid category ids.
+- Explicit typed inputs including a mandatory `summary` string rendered on the approval card.
+- Deletes/archives, record edits, and imports stay out of scope (dashboard only).
 
-### Workstream B: Draft -> Confirm -> Commit Protocol
+### Workstream B: Approval Flow — DONE (SDK-native)
 
-- Enforce a two-step flow:
-  1. Draft tool resolves symbol/position and validates missing fields.
-  2. Assistant asks only for unresolved required values (price/date/fees/description).
-  3. Commit tool executes only after explicit user approval.
-- Assistant must present a clear "execution summary" before commit:
-  - target position
-  - action type
-  - quantity and unit value
-  - effective date
-  - resulting quantity delta preview (if applicable)
+- `toolApproval: { createPortfolioRecord: 'user-approval', createPosition: 'user-approval' }`
+  in the chat route; the model's tool call pauses the turn with an approval request.
+- AI Elements `Confirmation` card shows the summary with Approve/Deny;
+  `addToolApprovalResponse` + `sendAutomaticallyWhen` resume the turn, which continues
+  into the same assistant message (persistence upserts, telemetry dedupes).
+- Composer is blocked while an approval is pending (an unanswered request would leave a
+  dangling tool call).
 
-### Workstream C: Safety, Permissions, and Auditability
+### Workstream C: Safety, Permissions, and Auditability — DONE (lean)
 
-- Approval is mandatory for all mutating tools (deny by default).
-- Add idempotency protection to prevent duplicate writes on retries/regenerations.
-- Persist audit metadata for each write:
-  - `approved_by_user` boolean
-  - `approved_at`
-  - `tool_call_id` / `conversation_id`
-  - `before_snapshot` and `after_snapshot` summary
-- Add strict server-side ownership checks (`user_id`) and schema validation.
-- Return user-friendly conflict errors (archived position, invalid date, currency mismatch, etc.).
+- Approval mandatory for all mutating tools; denial produces an `execution-denied` tool
+  result and the system prompt forbids retrying denied writes.
+- `TOOL_APPROVAL_SECRET` HMAC-signs approval requests (binds tool name + call id +
+  input); forged/tampered approvals are rejected fail-closed.
+- Server-side re-validation on the approval round-trip: signature, input schema, and
+  approval policy are all re-checked before execution.
+- Ownership via user-scoped Supabase client + RLS; all form validations (timeline,
+  oversell, duplicate name, currency FK) apply unchanged and return friendly errors.
+- Audit trail: conversation persistence stores every tool call with inputs, approval
+  state, and outputs; telemetry logs `write` route and `committed` outcome per turn.
+  (Dedicated audit table skipped — revisit if compliance needs arise.)
+- Known caveat: regenerating a turn whose write already committed can make the model
+  propose the same write again as a fresh approval. The user gate protects against
+  silent duplicates; DB-level idempotency would need a migration if this bites.
 
-### Workstream D: UX Details
+### Workstream D: UX Details — DONE
 
-- Approval card should show concise diff-style preview ("what will change").
-- After commit, assistant responds with a short confirmation and next best action.
-- Add "undo guidance" message when reversible via a counter-record.
+- Approval card shows a one-line plain-language summary of exactly what will change.
+- After commit, the advisor confirms briefly; the dashboard auto-refreshes
+  (`router.refresh()`) after a successful write.
+- Undo guidance: not implemented; counter-record advice is left to the model.
 
 ### Exit Criteria
 
 - > =90% of approved write intents complete without manual fallback.
 - <1% duplicate-write incidents.
 - Median write flow completion <=2 assistant turns after user intent.
-- Clear audit trail available for 100% of AI-triggered mutations.
+- AI-triggered mutations traceable via persisted tool calls + `committed` telemetry.
 
 ---
 

--- a/docs/ai/AI-ADVISOR-ROADMAP.md
+++ b/docs/ai/AI-ADVISOR-ROADMAP.md
@@ -242,6 +242,11 @@ Objective: let users update portfolio data directly from chat with explicit appr
 - Known caveat: regenerating a turn whose write already committed can make the model
   propose the same write again as a fresh approval. The user gate protects against
   silent duplicates; DB-level idempotency would need a migration if this bites.
+- Known caveat: an approved write is not idempotent — if the network response for the
+  approval continuation is lost and the client retries the same request, the tool can
+  execute twice (duplicate record). Requires a rare double failure. Proper fix is a
+  migration adding a unique idempotency key (e.g. the tool-call id) to the write path;
+  do together with the regenerate caveat above if either bites.
 
 ### Workstream D: UX Details — DONE
 

--- a/docs/ai/AI-ADVISOR-ROADMAP.md
+++ b/docs/ai/AI-ADVISOR-ROADMAP.md
@@ -230,8 +230,9 @@ Objective: let users update portfolio data directly from chat with explicit appr
 
 - Approval mandatory for all mutating tools; denial produces an `execution-denied` tool
   result and the system prompt forbids retrying denied writes.
-- `TOOL_APPROVAL_SECRET` HMAC-signs approval requests (binds tool name + call id +
-  input); forged/tampered approvals are rejected fail-closed.
+- When `TOOL_APPROVAL_SECRET` is configured, it HMAC-signs approval requests (binds
+  tool name + call id + input) and forged/tampered approvals are rejected fail-closed.
+  Without it approvals are unsigned (a production warning is logged) — set it in prod.
 - Server-side re-validation on the approval round-trip: signature, input schema, and
   approval policy are all re-checked before execution.
 - Ownership via user-scoped Supabase client + RLS; all form validations (timeline,

--- a/docs/ai/AI-ADVISOR-ROADMAP.md
+++ b/docs/ai/AI-ADVISOR-ROADMAP.md
@@ -242,11 +242,10 @@ Objective: let users update portfolio data directly from chat with explicit appr
 - Known caveat: regenerating a turn whose write already committed can make the model
   propose the same write again as a fresh approval. The user gate protects against
   silent duplicates; DB-level idempotency would need a migration if this bites.
-- Known caveat: an approved write is not idempotent — if the network response for the
-  approval continuation is lost and the client retries the same request, the tool can
-  execute twice (duplicate record). Requires a rare double failure. Proper fix is a
-  migration adding a unique idempotency key (e.g. the tool-call id) to the write path;
-  do together with the regenerate caveat above if either bites.
+- Approved record writes are replay-safe: the tool-call id is stored as
+  `portfolio_records.idempotency_key` (partial unique index per user), so a retried
+  approval continuation returns success without inserting a duplicate. `createPosition`
+  needs no key — the duplicate-name check already blocks a replayed create.
 
 ### Workstream D: UX Details — DONE
 

--- a/lib/ai/write-tools.test.ts
+++ b/lib/ai/write-tools.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import type { UIMessage } from "ai";
+
+import { hasSuccessfulWriteToolPart, isWriteToolPartType } from "./write-tools";
+
+function parts(...entries: unknown[]): UIMessage["parts"] {
+  return entries as UIMessage["parts"];
+}
+
+describe("write tool helpers", () => {
+  it("identifies only the write tool part types", () => {
+    expect(isWriteToolPartType("tool-createPortfolioRecord")).toBe(true);
+    expect(isWriteToolPartType("tool-createPosition")).toBe(true);
+    expect(isWriteToolPartType("tool-getPortfolioOverview")).toBe(false);
+    expect(isWriteToolPartType("text")).toBe(false);
+  });
+
+  it("detects successful writes and ignores failed or read tool outputs", () => {
+    expect(
+      hasSuccessfulWriteToolPart(
+        parts({
+          type: "tool-createPosition",
+          state: "output-available",
+          input: { summary: "Add" },
+          output: { success: true },
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      hasSuccessfulWriteToolPart(
+        parts({
+          type: "tool-createPosition",
+          state: "output-available",
+          input: { summary: "Add" },
+          output: { success: false, code: "DUPLICATE_NAME" },
+        }),
+      ),
+    ).toBe(false);
+
+    expect(
+      hasSuccessfulWriteToolPart(
+        parts({
+          type: "tool-getPortfolioOverview",
+          state: "output-available",
+          input: {},
+          output: { success: true },
+        }),
+      ),
+    ).toBe(false);
+
+    expect(
+      hasSuccessfulWriteToolPart(
+        parts({
+          type: "tool-createPortfolioRecord",
+          state: "output-denied",
+          input: { summary: "Buy" },
+          approval: { id: "approval-1", approved: false },
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/lib/ai/write-tools.ts
+++ b/lib/ai/write-tools.ts
@@ -1,0 +1,43 @@
+import { isStaticToolUIPart, type UIMessage } from "ai";
+
+// Single source of truth for the approval-gated AI write tools: the chat
+// route (fail-closed gating), chat UI (confirmation card, dashboard refresh),
+// and telemetry (committed outcome) all derive their checks from this list.
+export const AI_WRITE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "createPortfolioRecord",
+  "createPosition",
+]);
+
+const WRITE_TOOL_PART_TYPES: ReadonlySet<string> = new Set(
+  [...AI_WRITE_TOOL_NAMES].map((toolName) => `tool-${toolName}`),
+);
+
+export function isWriteToolPartType(partType: string): boolean {
+  return WRITE_TOOL_PART_TYPES.has(partType);
+}
+
+/**
+ * True when the parts contain a write tool that executed successfully,
+ * meaning portfolio data changed (dashboard RSC is stale, telemetry outcome
+ * is "committed").
+ */
+export function hasSuccessfulWriteToolPart(parts: UIMessage["parts"]): boolean {
+  if (!Array.isArray(parts)) {
+    return false;
+  }
+
+  return parts.some((part) => {
+    if (!isStaticToolUIPart(part)) {
+      return false;
+    }
+    if (!isWriteToolPartType(part.type)) {
+      return false;
+    }
+    if (part.state !== "output-available") {
+      return false;
+    }
+
+    const output = part.output as { success?: unknown } | null | undefined;
+    return output != null && output.success === true;
+  });
+}

--- a/lib/profit-loss/unrealized.test.ts
+++ b/lib/profit-loss/unrealized.test.ts
@@ -30,6 +30,7 @@ function createPosition(
     category_id: "cat-1",
     user_category_id: null,
     capital_gains_tax_rate: null,
+    idempotency_key: null,
     is_archived: false,
     category_name: "Category",
     user_category_name: null,

--- a/server/ai/conversations/persist.test.ts
+++ b/server/ai/conversations/persist.test.ts
@@ -104,6 +104,22 @@ class FakeQueryBuilder<T extends Record<string, unknown>> {
     return Promise.resolve({ data: null, error: null });
   }
 
+  upsert(value: Partial<T> | Partial<T>[]) {
+    const rows = Array.isArray(value) ? value : [value];
+    rows.forEach((row) => {
+      const existingIndex =
+        row.id == null
+          ? -1
+          : this.rowsRef.findIndex((existing) => existing.id === row.id);
+      if (existingIndex >= 0) {
+        this.rowsRef[existingIndex] = this.normalizeInsertRow(row);
+      } else {
+        this.rowsRef.push(this.normalizeInsertRow(row));
+      }
+    });
+    return Promise.resolve({ data: null, error: null });
+  }
+
   update(value: Partial<T>) {
     this.operation = "update";
     this.updatePayload = value;
@@ -433,6 +449,50 @@ describe("conversation persistence guardrails", () => {
     );
 
     expect(persistedAssistant?.id).toBe(assistantMessageId);
+  });
+
+  it("updates the stored assistant message on tool-approval continuation", async () => {
+    const { persistAssistantMessage } =
+      await import("@/server/ai/conversations/persist");
+
+    const assistantMessageId = "4c59a1ef-faa0-4f64-9050-c9ad0f0f3b52";
+    fakeSupabase.conversations = [
+      {
+        id: "continuation-conversation",
+        user_id: "user-1",
+        title: "Continuation Test",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ];
+
+    await persistAssistantMessage({
+      conversationId: "continuation-conversation",
+      message: createAssistantMessage(
+        assistantMessageId,
+        "Awaiting your approval",
+      ),
+      usageTokens: 100,
+    });
+
+    // Approval continuation streams into the same assistant message id.
+    await persistAssistantMessage({
+      conversationId: "continuation-conversation",
+      message: createAssistantMessage(
+        assistantMessageId,
+        "Done, the record was created",
+      ),
+      usageTokens: 150,
+    });
+
+    const assistantRows = fakeSupabase.conversationMessages.filter(
+      (message) => message.role === "assistant",
+    );
+
+    expect(assistantRows).toHaveLength(1);
+    expect(assistantRows[0]?.id).toBe(assistantMessageId);
+    expect(assistantRows[0]?.content).toBe("Done, the record was created");
+    expect(assistantRows[0]?.usage_tokens).toBe(150);
   });
 
   it("persists assistant message and trims when over message cap", async () => {

--- a/server/ai/conversations/persist.test.ts
+++ b/server/ai/conversations/persist.test.ts
@@ -493,6 +493,8 @@ describe("conversation persistence guardrails", () => {
     expect(assistantRows[0]?.id).toBe(assistantMessageId);
     expect(assistantRows[0]?.content).toBe("Done, the record was created");
     expect(assistantRows[0]?.usage_tokens).toBe(150);
+    // The continuation must keep the message's original position.
+    expect(assistantRows[0]?.order).toBe(0);
   });
 
   it("persists assistant message and trims when over message cap", async () => {

--- a/server/ai/conversations/persist.ts
+++ b/server/ai/conversations/persist.ts
@@ -269,7 +269,23 @@ async function insertConversationMessage(params: {
     model,
     usageTokens,
   } = params;
-  const messageOrder = await getNextMessageOrder(supabase, conversationId);
+
+  // A tool-approval continuation upserts into an existing assistant message:
+  // keep its original order instead of bumping it to the end again.
+  let existingOrder: number | null = null;
+  if (messageId) {
+    const { data: existingMessage } = await supabase
+      .from("conversation_messages")
+      .select("order")
+      .eq("id", messageId)
+      .eq("conversation_id", conversationId)
+      .eq("user_id", userId)
+      .maybeSingle();
+    existingOrder = existingMessage?.order ?? null;
+  }
+
+  const messageOrder =
+    existingOrder ?? (await getNextMessageOrder(supabase, conversationId));
 
   const insertPayload: {
     conversation_id: string;

--- a/server/ai/conversations/persist.ts
+++ b/server/ai/conversations/persist.ts
@@ -295,9 +295,12 @@ async function insertConversationMessage(params: {
     insertPayload.id = messageId;
   }
 
+  // Upsert instead of insert: a tool-approval continuation streams into the
+  // same assistant message id, so the second pass must update the stored row.
+  // User turns carry no id, so upsert keeps plain insert semantics for them.
   const { error } = await supabase
     .from("conversation_messages")
-    .insert(insertPayload);
+    .upsert(insertPayload);
 
   if (error) {
     throw new Error(`Failed to persist conversation message: ${error.message}`);

--- a/server/ai/system-prompt.ts
+++ b/server/ai/system-prompt.ts
@@ -105,6 +105,15 @@ TOOL ROUTING
 - For broad portfolio scans (e.g., drawdowns/highs across many holdings), use aggregate analysis tools first and only request per-symbol historical quotes for a narrowed subset.
 - If you need historical quotes for multiple symbols in the same window, prefer the batch historical-quotes tool instead of repeated single-symbol calls.
 
+PORTFOLIO WRITES (approval-gated)
+- You can modify the portfolio on the user's request: createPortfolioRecord for buy/sell/update on an existing position (use \`positions[].id\`), createPosition only for holdings not tracked yet.
+- Call getPositionCategories before createPosition to pick a valid category, unless the category is clearly "other".
+- Gather real data first: resolve the position id via overview/read tools, and if the user did not state a price, look up the market price instead of inventing one. Never fabricate quantities, prices, or dates.
+- The \`summary\` input must state exactly what will happen (action, quantity, asset, price, currency, date).
+- Every write requires the user's explicit approval in the UI. Propose one write at a time and wait for its outcome before proposing the next.
+- If the user denies a write, do not retry it; ask what they want to change instead.
+- After a successful write, confirm briefly what changed. If the tool returns success: false, relay the message in plain terms and suggest a fix.
+
 OUTPUT FORMAT
 - Lead with a direct answer in 1-2 sentences.
 - Then provide at most 3 bullets with key data points or trade-offs.

--- a/server/ai/telemetry/track-assistant-turn.insert.test.ts
+++ b/server/ai/telemetry/track-assistant-turn.insert.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { UIMessage } from "ai";
 
-const insertMock = vi.fn();
+const upsertMock = vi.fn();
 const fromMock = vi.fn();
 const getUserMock = vi.fn();
 
@@ -13,18 +13,18 @@ vi.mock("@/supabase/server", () => ({
   }),
 }));
 
-describe("trackAssistantTurn insert behavior", () => {
+describe("trackAssistantTurn upsert behavior", () => {
   beforeEach(() => {
-    insertMock.mockReset();
+    upsertMock.mockReset();
     fromMock.mockReset();
     getUserMock.mockReset();
 
-    insertMock.mockResolvedValue({ error: null });
-    fromMock.mockReturnValue({ insert: insertMock });
+    upsertMock.mockResolvedValue({ error: null });
+    fromMock.mockReturnValue({ upsert: upsertMock });
     getUserMock.mockResolvedValue({ data: { user: { id: "user-1" } } });
   });
 
-  it("skips insert when assistant_message_id is not a UUID", async () => {
+  it("skips upsert when assistant_message_id is not a UUID", async () => {
     const { trackAssistantTurn } =
       await import("@/server/ai/telemetry/track-assistant-turn");
 
@@ -41,10 +41,10 @@ describe("trackAssistantTurn insert behavior", () => {
       finishReason: "stop",
     });
 
-    expect(insertMock).not.toHaveBeenCalled();
+    expect(upsertMock).not.toHaveBeenCalled();
   });
 
-  it("skips insert when conversation_id is not a UUID", async () => {
+  it("skips upsert when conversation_id is not a UUID", async () => {
     const { trackAssistantTurn } =
       await import("@/server/ai/telemetry/track-assistant-turn");
 
@@ -61,10 +61,10 @@ describe("trackAssistantTurn insert behavior", () => {
       finishReason: "stop",
     });
 
-    expect(insertMock).not.toHaveBeenCalled();
+    expect(upsertMock).not.toHaveBeenCalled();
   });
 
-  it("inserts telemetry when IDs are valid UUIDs", async () => {
+  it("upserts telemetry keyed on assistant_message_id when IDs are valid UUIDs", async () => {
     const { trackAssistantTurn } =
       await import("@/server/ai/telemetry/track-assistant-turn");
 
@@ -81,13 +81,15 @@ describe("trackAssistantTurn insert behavior", () => {
       finishReason: "stop",
     });
 
-    expect(insertMock).toHaveBeenCalledTimes(1);
-    expect(insertMock).toHaveBeenCalledWith(
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    expect(upsertMock).toHaveBeenCalledWith(
       expect.objectContaining({
         conversation_id: "d9ef7f5c-9077-4703-8164-802e44f278a1",
         assistant_message_id: "c18d1bdf-32ef-4f5a-9c37-d44229f1e7ea",
         routes: ["general"],
       }),
+      // Tool-approval continuations re-report the same assistant message.
+      { onConflict: "assistant_message_id" },
     );
   });
 });

--- a/server/ai/telemetry/track-assistant-turn.test.ts
+++ b/server/ai/telemetry/track-assistant-turn.test.ts
@@ -95,4 +95,73 @@ describe("track-assistant-turn helpers", () => {
 
     expect(outcome).toBe("ok");
   });
+
+  it("classifies write route for write tools", () => {
+    const routes = resolveAssistantRoutes([
+      { type: "tool-createPortfolioRecord", state: "output-available" },
+    ] as unknown as AssistantParts);
+
+    expect(routes).toEqual(["write"]);
+  });
+
+  it("returns committed outcome for a successful write tool output", () => {
+    const outcome = resolveAssistantOutcome({
+      parts: [
+        {
+          type: "tool-createPortfolioRecord",
+          state: "output-available",
+          output: { success: true },
+        },
+      ] as unknown as AssistantParts,
+      finishReason: "stop",
+    });
+
+    expect(outcome).toBe("committed");
+  });
+
+  it("does not return committed when the write tool output failed", () => {
+    const outcome = resolveAssistantOutcome({
+      parts: [
+        {
+          type: "tool-createPosition",
+          state: "output-available",
+          output: { success: false, code: "DUPLICATE_NAME" },
+        },
+      ] as unknown as AssistantParts,
+      finishReason: "stop",
+    });
+
+    expect(outcome).toBe("ok");
+  });
+
+  it("returns error when a write tool was denied even alongside a committed one", () => {
+    const outcome = resolveAssistantOutcome({
+      parts: [
+        {
+          type: "tool-createPortfolioRecord",
+          state: "output-available",
+          output: { success: true },
+        },
+        { type: "tool-createPosition", state: "output-denied" },
+      ] as unknown as AssistantParts,
+      finishReason: "stop",
+    });
+
+    expect(outcome).toBe("error");
+  });
+
+  it("does not return committed for successful read tool outputs", () => {
+    const outcome = resolveAssistantOutcome({
+      parts: [
+        {
+          type: "tool-getPortfolioOverview",
+          state: "output-available",
+          output: { success: true },
+        },
+      ] as unknown as AssistantParts,
+      finishReason: "stop",
+    });
+
+    expect(outcome).toBe("ok");
+  });
 });

--- a/server/ai/telemetry/track-assistant-turn.ts
+++ b/server/ai/telemetry/track-assistant-turn.ts
@@ -2,10 +2,8 @@ import type { FinishReason, UIMessage } from "ai";
 import { z } from "zod";
 
 import { createClient } from "@/supabase/server";
-import {
-  resolveRoutesFromMessageParts,
-  resolveRoutesFromToolPartType,
-} from "@/server/ai/tooling/tool-route-registry";
+import { hasSuccessfulWriteToolPart } from "@/lib/ai/write-tools";
+import { resolveRoutesFromMessageParts } from "@/server/ai/tooling/tool-route-registry";
 import type {
   AIAssistantOutcome,
   AIAssistantPromptSource,
@@ -61,25 +59,6 @@ export function resolveAssistantRoutes(
   return resolveRoutesFromMessageParts(parts);
 }
 
-function hasCommittedWrite(parts: UIMessage["parts"]): boolean {
-  if (!Array.isArray(parts)) return false;
-
-  return parts.some((part) => {
-    if (!("state" in part) || part.state !== "output-available") return false;
-
-    const routes = resolveRoutesFromToolPartType(part.type);
-    if (!routes?.includes("write")) return false;
-
-    const output = "output" in part ? part.output : null;
-    return (
-      typeof output === "object" &&
-      output !== null &&
-      "success" in output &&
-      output.success === true
-    );
-  });
-}
-
 /**
  * Resolve the assistant turn outcome for telemetry.
  */
@@ -95,7 +74,7 @@ export function resolveAssistantOutcome({
     return "error";
   }
 
-  if (hasCommittedWrite(parts)) {
+  if (hasSuccessfulWriteToolPart(parts)) {
     return "committed";
   }
 

--- a/server/ai/telemetry/track-assistant-turn.ts
+++ b/server/ai/telemetry/track-assistant-turn.ts
@@ -2,7 +2,10 @@ import type { FinishReason, UIMessage } from "ai";
 import { z } from "zod";
 
 import { createClient } from "@/supabase/server";
-import { resolveRoutesFromMessageParts } from "@/server/ai/tooling/tool-route-registry";
+import {
+  resolveRoutesFromMessageParts,
+  resolveRoutesFromToolPartType,
+} from "@/server/ai/tooling/tool-route-registry";
 import type {
   AIAssistantOutcome,
   AIAssistantPromptSource,
@@ -58,6 +61,25 @@ export function resolveAssistantRoutes(
   return resolveRoutesFromMessageParts(parts);
 }
 
+function hasCommittedWrite(parts: UIMessage["parts"]): boolean {
+  if (!Array.isArray(parts)) return false;
+
+  return parts.some((part) => {
+    if (!("state" in part) || part.state !== "output-available") return false;
+
+    const routes = resolveRoutesFromToolPartType(part.type);
+    if (!routes?.includes("write")) return false;
+
+    const output = "output" in part ? part.output : null;
+    return (
+      typeof output === "object" &&
+      output !== null &&
+      "success" in output &&
+      output.success === true
+    );
+  });
+}
+
 /**
  * Resolve the assistant turn outcome for telemetry.
  */
@@ -71,6 +93,10 @@ export function resolveAssistantOutcome({
 
   if (hasToolErrorOrDeniedState(parts)) {
     return "error";
+  }
+
+  if (hasCommittedWrite(parts)) {
+    return "committed";
   }
 
   return "ok";
@@ -107,16 +133,23 @@ export async function trackAssistantTurn(
   });
   const assistantChars = getAssistantTextCharCount(params.message.parts);
 
-  const { error } = await supabase.from("ai_assistant_turn_events").insert({
-    conversation_id: conversationIdParse.data,
-    assistant_message_id: assistantMessageIdParse.data,
-    user_id: userId,
-    model: params.model,
-    prompt_source: params.promptSource,
-    routes,
-    outcome,
-    assistant_chars: assistantChars,
-  });
+  // One row per assistant message (DB unique constraint): tool-approval
+  // continuations re-report the same message id and update the row in place.
+  // The continuation resend carries no promptSource, so a suggestion-initiated
+  // turn may normalize to "typed" on continuation — accepted drift.
+  const { error } = await supabase.from("ai_assistant_turn_events").upsert(
+    {
+      conversation_id: conversationIdParse.data,
+      assistant_message_id: assistantMessageIdParse.data,
+      user_id: userId,
+      model: params.model,
+      prompt_source: params.promptSource,
+      routes,
+      outcome,
+      assistant_chars: assistantChars,
+    },
+    { onConflict: "assistant_message_id" },
+  );
 
   if (error) {
     throw new Error(

--- a/server/ai/tooling/tool-route-registry.ts
+++ b/server/ai/tooling/tool-route-registry.ts
@@ -42,6 +42,16 @@ function parseToolNameFromPartType(partType: string): AIToolName | null {
 }
 
 /**
+ * Resolve telemetry routes for a single UI message part type (e.g. "tool-getNews").
+ */
+export function resolveRoutesFromToolPartType(
+  partType: string,
+): TelemetryRoutes | null {
+  const toolName = parseToolNameFromPartType(partType);
+  return toolName ? AI_TOOL_ROUTE_REGISTRY[toolName] : null;
+}
+
+/**
  * Resolve telemetry routes from tool parts used in a single assistant turn.
  */
 export function resolveRoutesFromMessageParts(

--- a/server/ai/tooling/tool-route-registry.ts
+++ b/server/ai/tooling/tool-route-registry.ts
@@ -42,16 +42,6 @@ function parseToolNameFromPartType(partType: string): AIToolName | null {
 }
 
 /**
- * Resolve telemetry routes for a single UI message part type (e.g. "tool-getNews").
- */
-export function resolveRoutesFromToolPartType(
-  partType: string,
-): TelemetryRoutes | null {
-  const toolName = parseToolNameFromPartType(partType);
-  return toolName ? AI_TOOL_ROUTE_REGISTRY[toolName] : null;
-}
-
-/**
  * Resolve telemetry routes from tool parts used in a single assistant turn.
  */
 export function resolveRoutesFromMessageParts(

--- a/server/ai/tools/create-portfolio-record.test.ts
+++ b/server/ai/tools/create-portfolio-record.test.ts
@@ -24,6 +24,7 @@ describe("createPortfolioRecord AI tool", () => {
       unitValue: 211.5,
       description: "Broker sync",
       costBasisPerUnit: null,
+      idempotencyKey: null,
     });
 
     const formData = createPortfolioRecordMutationMock.mock
@@ -48,6 +49,7 @@ describe("createPortfolioRecord AI tool", () => {
       unitValue: 100,
       description: null,
       costBasisPerUnit: null,
+      idempotencyKey: null,
     });
 
     const formData = createPortfolioRecordMutationMock.mock
@@ -55,6 +57,25 @@ describe("createPortfolioRecord AI tool", () => {
     expect(formData.has("description")).toBe(false);
     expect(formData.has("cost_basis_per_unit")).toBe(false);
     expect(formData.has("summary")).toBe(false);
+    expect(formData.has("idempotency_key")).toBe(false);
+  });
+
+  it("forwards the idempotency key for replay-safe writes", async () => {
+    await createPortfolioRecord({
+      summary: "Buy 20 × AAPL",
+      positionId: "0b0e4f9a-95ea-4c22-9c37-d44229f1e7ea",
+      type: "buy",
+      date: "2026-07-18",
+      quantity: 20,
+      unitValue: 211.5,
+      description: null,
+      costBasisPerUnit: null,
+      idempotencyKey: "call_abc123",
+    });
+
+    const formData = createPortfolioRecordMutationMock.mock
+      .calls[0]?.[0] as FormData;
+    expect(formData.get("idempotency_key")).toBe("call_abc123");
   });
 
   it("passes custom cost basis for update records", async () => {
@@ -67,6 +88,7 @@ describe("createPortfolioRecord AI tool", () => {
       unitValue: 80,
       description: null,
       costBasisPerUnit: 75.25,
+      idempotencyKey: null,
     });
 
     const formData = createPortfolioRecordMutationMock.mock
@@ -91,6 +113,7 @@ describe("createPortfolioRecord AI tool", () => {
       unitValue: 211.5,
       description: null,
       costBasisPerUnit: null,
+      idempotencyKey: null,
     });
 
     expect(result).toBe(failure);

--- a/server/ai/tools/create-portfolio-record.test.ts
+++ b/server/ai/tools/create-portfolio-record.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createPortfolioRecordMutationMock = vi.fn();
+
+vi.mock("@/server/portfolio-records/create", () => ({
+  createPortfolioRecord: createPortfolioRecordMutationMock,
+}));
+
+const { createPortfolioRecord } = await import("./create-portfolio-record");
+
+describe("createPortfolioRecord AI tool", () => {
+  beforeEach(() => {
+    createPortfolioRecordMutationMock.mockReset();
+    createPortfolioRecordMutationMock.mockResolvedValue({ success: true });
+  });
+
+  it("marshals args into the mutation FormData shape", async () => {
+    await createPortfolioRecord({
+      summary: "Buy 20 × AAPL @ 211.50 USD on 2026-07-18",
+      positionId: "0b0e4f9a-95ea-4c22-9c37-d44229f1e7ea",
+      type: "buy",
+      date: "2026-07-18",
+      quantity: 20,
+      unitValue: 211.5,
+      description: "Broker sync",
+      costBasisPerUnit: null,
+    });
+
+    const formData = createPortfolioRecordMutationMock.mock
+      .calls[0]?.[0] as FormData;
+    expect(formData.get("position_id")).toBe(
+      "0b0e4f9a-95ea-4c22-9c37-d44229f1e7ea",
+    );
+    expect(formData.get("type")).toBe("buy");
+    expect(formData.get("date")).toBe("2026-07-18");
+    expect(formData.get("quantity")).toBe("20");
+    expect(formData.get("unit_value")).toBe("211.5");
+    expect(formData.get("description")).toBe("Broker sync");
+  });
+
+  it("omits null optionals and the UI-only summary", async () => {
+    await createPortfolioRecord({
+      summary: "Sell 5 × MSFT",
+      positionId: "0b0e4f9a-95ea-4c22-9c37-d44229f1e7ea",
+      type: "sell",
+      date: "2026-07-18",
+      quantity: 5,
+      unitValue: 100,
+      description: null,
+      costBasisPerUnit: null,
+    });
+
+    const formData = createPortfolioRecordMutationMock.mock
+      .calls[0]?.[0] as FormData;
+    expect(formData.has("description")).toBe(false);
+    expect(formData.has("cost_basis_per_unit")).toBe(false);
+    expect(formData.has("summary")).toBe(false);
+  });
+
+  it("passes custom cost basis for update records", async () => {
+    await createPortfolioRecord({
+      summary: "Update quantity",
+      positionId: "0b0e4f9a-95ea-4c22-9c37-d44229f1e7ea",
+      type: "update",
+      date: "2026-07-18",
+      quantity: 12,
+      unitValue: 80,
+      description: null,
+      costBasisPerUnit: 75.25,
+    });
+
+    const formData = createPortfolioRecordMutationMock.mock
+      .calls[0]?.[0] as FormData;
+    expect(formData.get("cost_basis_per_unit")).toBe("75.25");
+  });
+
+  it("returns the mutation result verbatim", async () => {
+    const failure = {
+      success: false,
+      code: "INSUFFICIENT_QUANTITY",
+      message: "Cannot sell more than held",
+    };
+    createPortfolioRecordMutationMock.mockResolvedValue(failure);
+
+    const result = await createPortfolioRecord({
+      summary: "Sell 500 × AAPL",
+      positionId: "0b0e4f9a-95ea-4c22-9c37-d44229f1e7ea",
+      type: "sell",
+      date: "2026-07-18",
+      quantity: 500,
+      unitValue: 211.5,
+      description: null,
+      costBasisPerUnit: null,
+    });
+
+    expect(result).toBe(failure);
+  });
+});

--- a/server/ai/tools/create-portfolio-record.ts
+++ b/server/ai/tools/create-portfolio-record.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { createPortfolioRecord as createPortfolioRecordMutation } from "@/server/portfolio-records/create";
+
+interface CreatePortfolioRecordParams {
+  summary: string;
+  positionId: string;
+  type: "buy" | "sell" | "update";
+  date: string; // YYYY-MM-DD
+  quantity: number;
+  unitValue: number;
+  description: string | null;
+  costBasisPerUnit: number | null;
+}
+
+/**
+ * Approval-gated write tool: marshals typed AI tool args into the FormData
+ * shape of the shared createPortfolioRecord mutation (single write path used
+ * by forms and imports). `summary` is consumed by the approval UI only.
+ */
+export async function createPortfolioRecord(
+  params: CreatePortfolioRecordParams,
+) {
+  const formData = new FormData();
+  formData.set("position_id", params.positionId);
+  formData.set("type", params.type);
+  formData.set("date", params.date);
+  formData.set("quantity", String(params.quantity));
+  formData.set("unit_value", String(params.unitValue));
+  if (params.description != null) {
+    formData.set("description", params.description);
+  }
+  if (params.costBasisPerUnit != null) {
+    formData.set("cost_basis_per_unit", String(params.costBasisPerUnit));
+  }
+
+  return createPortfolioRecordMutation(formData);
+}

--- a/server/ai/tools/create-portfolio-record.ts
+++ b/server/ai/tools/create-portfolio-record.ts
@@ -11,6 +11,7 @@ interface CreatePortfolioRecordParams {
   unitValue: number;
   description: string | null;
   costBasisPerUnit: number | null;
+  idempotencyKey: string | null;
 }
 
 /**
@@ -32,6 +33,9 @@ export async function createPortfolioRecord(
   }
   if (params.costBasisPerUnit != null) {
     formData.set("cost_basis_per_unit", String(params.costBasisPerUnit));
+  }
+  if (params.idempotencyKey != null) {
+    formData.set("idempotency_key", params.idempotencyKey);
   }
 
   return createPortfolioRecordMutation(formData);

--- a/server/ai/tools/create-position.test.ts
+++ b/server/ai/tools/create-position.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createPositionMutationMock = vi.fn();
+
+vi.mock("@/server/positions/create", () => ({
+  createPosition: createPositionMutationMock,
+}));
+
+const { createPosition } = await import("./create-position");
+
+const baseParams = {
+  summary: "Add position VWCE.DE: 15 units (ETFs)",
+  name: "Vanguard FTSE All-World",
+  currency: "EUR",
+  type: null,
+  categoryId: null,
+  userCategoryId: null,
+  symbolLookup: null,
+  quantity: null,
+  unitValue: null,
+  costBasisPerUnit: null,
+  capitalGainsTaxRate: null,
+  date: null,
+  description: null,
+};
+
+describe("createPosition AI tool", () => {
+  beforeEach(() => {
+    createPositionMutationMock.mockReset();
+    createPositionMutationMock.mockResolvedValue({ success: true });
+  });
+
+  it("marshals all provided args into the mutation FormData shape", async () => {
+    await createPosition({
+      ...baseParams,
+      type: "asset",
+      categoryId: "etfs",
+      symbolLookup: "VWCE.DE",
+      quantity: 15,
+      unitValue: 130.2,
+      costBasisPerUnit: 120,
+      capitalGainsTaxRate: 26,
+      date: "2026-07-18",
+      description: "Broker sync",
+    });
+
+    const formData = createPositionMutationMock.mock.calls[0]?.[0] as FormData;
+    expect(formData.get("name")).toBe("Vanguard FTSE All-World");
+    expect(formData.get("currency")).toBe("EUR");
+    expect(formData.get("type")).toBe("asset");
+    expect(formData.get("category_id")).toBe("etfs");
+    expect(formData.get("symbolLookup")).toBe("VWCE.DE");
+    expect(formData.get("quantity")).toBe("15");
+    expect(formData.get("unit_value")).toBe("130.2");
+    expect(formData.get("cost_basis_per_unit")).toBe("120");
+    expect(formData.get("capital_gains_tax_rate")).toBe("26");
+    expect(formData.get("date")).toBe("2026-07-18");
+    expect(formData.get("description")).toBe("Broker sync");
+  });
+
+  it("omits null optionals so the mutation keeps its defaults", async () => {
+    await createPosition(baseParams);
+
+    const formData = createPositionMutationMock.mock.calls[0]?.[0] as FormData;
+    expect(formData.get("name")).toBe("Vanguard FTSE All-World");
+    expect(formData.get("currency")).toBe("EUR");
+    for (const key of [
+      "type",
+      "category_id",
+      "user_category_id",
+      "symbolLookup",
+      "quantity",
+      "unit_value",
+      "cost_basis_per_unit",
+      "capital_gains_tax_rate",
+      "date",
+      "description",
+      "summary",
+    ]) {
+      expect(formData.has(key)).toBe(false);
+    }
+  });
+
+  it("supports custom user categories", async () => {
+    await createPosition({
+      ...baseParams,
+      userCategoryId: "9a1f61a1-51b2-4c53-a2be-2f9b31c1a111",
+    });
+
+    const formData = createPositionMutationMock.mock.calls[0]?.[0] as FormData;
+    expect(formData.get("user_category_id")).toBe(
+      "9a1f61a1-51b2-4c53-a2be-2f9b31c1a111",
+    );
+  });
+
+  it("returns the mutation result verbatim", async () => {
+    const failure = {
+      success: false,
+      code: "DUPLICATE_NAME",
+      message: "A position with this name already exists",
+    };
+    createPositionMutationMock.mockResolvedValue(failure);
+
+    const result = await createPosition(baseParams);
+
+    expect(result).toBe(failure);
+  });
+});

--- a/server/ai/tools/create-position.test.ts
+++ b/server/ai/tools/create-position.test.ts
@@ -53,9 +53,17 @@ describe("createPosition AI tool", () => {
     expect(formData.get("quantity")).toBe("15");
     expect(formData.get("unit_value")).toBe("130.2");
     expect(formData.get("cost_basis_per_unit")).toBe("120");
-    expect(formData.get("capital_gains_tax_rate")).toBe("26");
+    // Model provides a percentage; the DB CHECK requires a 0..1 decimal.
+    expect(formData.get("capital_gains_tax_rate")).toBe("0.26");
     expect(formData.get("date")).toBe("2026-07-18");
     expect(formData.get("description")).toBe("Broker sync");
+  });
+
+  it("keeps an already-decimal tax rate unchanged", async () => {
+    await createPosition({ ...baseParams, capitalGainsTaxRate: 0.26 });
+
+    const formData = createPositionMutationMock.mock.calls[0]?.[0] as FormData;
+    expect(formData.get("capital_gains_tax_rate")).toBe("0.26");
   });
 
   it("omits null optionals so the mutation keeps its defaults", async () => {

--- a/server/ai/tools/create-position.test.ts
+++ b/server/ai/tools/create-position.test.ts
@@ -22,6 +22,7 @@ const baseParams = {
   capitalGainsTaxRate: null,
   date: "2026-07-18",
   description: null,
+  idempotencyKey: "call_abc123",
 };
 
 describe("createPosition AI tool", () => {
@@ -57,6 +58,7 @@ describe("createPosition AI tool", () => {
     expect(formData.get("capital_gains_tax_rate")).toBe("0.26");
     expect(formData.get("date")).toBe("2026-07-18");
     expect(formData.get("description")).toBe("Broker sync");
+    expect(formData.get("idempotency_key")).toBe("call_abc123");
   });
 
   it("treats small rates as percentages too (1 means 1%, not 100%)", async () => {

--- a/server/ai/tools/create-position.test.ts
+++ b/server/ai/tools/create-position.test.ts
@@ -20,7 +20,7 @@ const baseParams = {
   unitValue: null,
   costBasisPerUnit: null,
   capitalGainsTaxRate: null,
-  date: null,
+  date: "2026-07-18",
   description: null,
 };
 
@@ -59,11 +59,11 @@ describe("createPosition AI tool", () => {
     expect(formData.get("description")).toBe("Broker sync");
   });
 
-  it("keeps an already-decimal tax rate unchanged", async () => {
-    await createPosition({ ...baseParams, capitalGainsTaxRate: 0.26 });
+  it("treats small rates as percentages too (1 means 1%, not 100%)", async () => {
+    await createPosition({ ...baseParams, capitalGainsTaxRate: 1 });
 
     const formData = createPositionMutationMock.mock.calls[0]?.[0] as FormData;
-    expect(formData.get("capital_gains_tax_rate")).toBe("0.26");
+    expect(formData.get("capital_gains_tax_rate")).toBe("0.01");
   });
 
   it("omits null optionals so the mutation keeps its defaults", async () => {
@@ -72,6 +72,7 @@ describe("createPosition AI tool", () => {
     const formData = createPositionMutationMock.mock.calls[0]?.[0] as FormData;
     expect(formData.get("name")).toBe("Vanguard FTSE All-World");
     expect(formData.get("currency")).toBe("EUR");
+    expect(formData.get("date")).toBe("2026-07-18");
     for (const key of [
       "type",
       "category_id",
@@ -81,7 +82,6 @@ describe("createPosition AI tool", () => {
       "unit_value",
       "cost_basis_per_unit",
       "capital_gains_tax_rate",
-      "date",
       "description",
       "summary",
     ]) {

--- a/server/ai/tools/create-position.ts
+++ b/server/ai/tools/create-position.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { createPosition as createPositionMutation } from "@/server/positions/create";
+
+interface CreatePositionParams {
+  summary: string;
+  name: string;
+  currency: string;
+  type: "asset" | "liability" | null;
+  categoryId: string | null;
+  userCategoryId: string | null;
+  symbolLookup: string | null;
+  quantity: number | null;
+  unitValue: number | null;
+  costBasisPerUnit: number | null;
+  capitalGainsTaxRate: number | null;
+  date: string | null; // YYYY-MM-DD
+  description: string | null;
+}
+
+/**
+ * Approval-gated write tool: marshals typed AI tool args into the FormData
+ * shape of the shared createPosition mutation (single write path used by
+ * forms and imports). `summary` is consumed by the approval UI only.
+ * Omitted optionals keep the mutation defaults (quantity 0, quote-derived
+ * unit value when a symbol is provided, category fallback "other").
+ */
+export async function createPosition(params: CreatePositionParams) {
+  const formData = new FormData();
+  formData.set("name", params.name);
+  formData.set("currency", params.currency);
+  if (params.type != null) {
+    formData.set("type", params.type);
+  }
+  if (params.categoryId != null) {
+    formData.set("category_id", params.categoryId);
+  }
+  if (params.userCategoryId != null) {
+    formData.set("user_category_id", params.userCategoryId);
+  }
+  if (params.symbolLookup != null) {
+    formData.set("symbolLookup", params.symbolLookup);
+  }
+  if (params.quantity != null) {
+    formData.set("quantity", String(params.quantity));
+  }
+  if (params.unitValue != null) {
+    formData.set("unit_value", String(params.unitValue));
+  }
+  if (params.costBasisPerUnit != null) {
+    formData.set("cost_basis_per_unit", String(params.costBasisPerUnit));
+  }
+  if (params.capitalGainsTaxRate != null) {
+    formData.set("capital_gains_tax_rate", String(params.capitalGainsTaxRate));
+  }
+  if (params.date != null) {
+    formData.set("date", params.date);
+  }
+  if (params.description != null) {
+    formData.set("description", params.description);
+  }
+
+  return createPositionMutation(formData);
+}

--- a/server/ai/tools/create-position.ts
+++ b/server/ai/tools/create-position.ts
@@ -2,6 +2,8 @@
 
 import { createPosition as createPositionMutation } from "@/server/positions/create";
 
+import { normalizeCapitalGainsTaxRateToDecimal } from "@/lib/capital-gains-tax-rate";
+
 interface CreatePositionParams {
   summary: string;
   name: string;
@@ -50,8 +52,12 @@ export async function createPosition(params: CreatePositionParams) {
   if (params.costBasisPerUnit != null) {
     formData.set("cost_basis_per_unit", String(params.costBasisPerUnit));
   }
-  if (params.capitalGainsTaxRate != null) {
-    formData.set("capital_gains_tax_rate", String(params.capitalGainsTaxRate));
+  // The model provides a percentage (e.g., 26); the DB stores a decimal (0.26).
+  const capitalGainsTaxRateDecimal = normalizeCapitalGainsTaxRateToDecimal(
+    params.capitalGainsTaxRate,
+  );
+  if (capitalGainsTaxRateDecimal != null) {
+    formData.set("capital_gains_tax_rate", String(capitalGainsTaxRateDecimal));
   }
   if (params.date != null) {
     formData.set("date", params.date);

--- a/server/ai/tools/create-position.ts
+++ b/server/ai/tools/create-position.ts
@@ -16,6 +16,7 @@ interface CreatePositionParams {
   capitalGainsTaxRate: number | null;
   date: string; // YYYY-MM-DD
   description: string | null;
+  idempotencyKey: string;
 }
 
 /**
@@ -62,6 +63,7 @@ export async function createPosition(params: CreatePositionParams) {
   if (params.description != null) {
     formData.set("description", params.description);
   }
+  formData.set("idempotency_key", params.idempotencyKey);
 
   return createPositionMutation(formData);
 }

--- a/server/ai/tools/create-position.ts
+++ b/server/ai/tools/create-position.ts
@@ -2,8 +2,6 @@
 
 import { createPosition as createPositionMutation } from "@/server/positions/create";
 
-import { normalizeCapitalGainsTaxRateToDecimal } from "@/lib/capital-gains-tax-rate";
-
 interface CreatePositionParams {
   summary: string;
   name: string;
@@ -16,7 +14,7 @@ interface CreatePositionParams {
   unitValue: number | null;
   costBasisPerUnit: number | null;
   capitalGainsTaxRate: number | null;
-  date: string | null; // YYYY-MM-DD
+  date: string; // YYYY-MM-DD
   description: string | null;
 }
 
@@ -52,16 +50,15 @@ export async function createPosition(params: CreatePositionParams) {
   if (params.costBasisPerUnit != null) {
     formData.set("cost_basis_per_unit", String(params.costBasisPerUnit));
   }
-  // The model provides a percentage (e.g., 26); the DB stores a decimal (0.26).
-  const capitalGainsTaxRateDecimal = normalizeCapitalGainsTaxRateToDecimal(
-    params.capitalGainsTaxRate,
-  );
-  if (capitalGainsTaxRateDecimal != null) {
-    formData.set("capital_gains_tax_rate", String(capitalGainsTaxRateDecimal));
+  // The schema guarantees a 0-100 percentage; the DB stores a 0..1 decimal.
+  // Always divide (no mixed-unit heuristic) so 1 means 1%, not 100%.
+  if (params.capitalGainsTaxRate != null) {
+    formData.set(
+      "capital_gains_tax_rate",
+      String(params.capitalGainsTaxRate / 100),
+    );
   }
-  if (params.date != null) {
-    formData.set("date", params.date);
-  }
+  formData.set("date", params.date);
   if (params.description != null) {
     formData.set("description", params.description);
   }

--- a/server/ai/tools/index.ts
+++ b/server/ai/tools/index.ts
@@ -31,6 +31,16 @@ import { createPortfolioRecord } from "./create-portfolio-record";
 import { createPosition } from "./create-position";
 import { getPositionCategories } from "./position-categories";
 
+import { toCivilDateKey } from "@/lib/date/date-utils";
+
+// Write-tool dates must be real calendar dates (rejects e.g. 2026-02-30);
+// validation errors surface to the model for a retry before the approval card.
+const writeDateKeySchema = z
+  .string()
+  .refine((value) => toCivilDateKey(value) !== null, {
+    error: "Must be a real date in YYYY-MM-DD format.",
+  });
+
 export const aiTools = {
   getPortfolioOverview: routedTool({
     telemetryRoutes: ["general"],
@@ -469,10 +479,7 @@ export const aiTools = {
         .describe(
           "'buy' adds quantity, 'sell' removes quantity, 'update' resets quantity and unit value at a date.",
         ),
-      date: z
-        .string()
-        .regex(/^\d{4}-\d{2}-\d{2}$/)
-        .describe("Record date in YYYY-MM-DD format."),
+      date: writeDateKeySchema.describe("Record date in YYYY-MM-DD format."),
       quantity: z
         .number()
         .min(0)
@@ -564,13 +571,9 @@ export const aiTools = {
         .max(100)
         .nullable()
         .describe("Capital gains tax rate percentage, 0-100 (e.g., 26)."),
-      date: z
-        .string()
-        .regex(/^\d{4}-\d{2}-\d{2}$/)
-        .nullable()
-        .describe(
-          "Initial snapshot date in YYYY-MM-DD format. Leave empty for today.",
-        ),
+      date: writeDateKeySchema.describe(
+        "Initial snapshot date in YYYY-MM-DD format. Use the current date unless the user specifies another.",
+      ),
       description: z
         .string()
         .nullable()

--- a/server/ai/tools/index.ts
+++ b/server/ai/tools/index.ts
@@ -26,6 +26,11 @@ import { getProductReference } from "./product-reference";
 // Financial scenarios
 import { getFinancialScenarios } from "./financial-scenarios";
 
+// Portfolio writes (approval-gated)
+import { createPortfolioRecord } from "./create-portfolio-record";
+import { createPosition } from "./create-position";
+import { getPositionCategories } from "./position-categories";
+
 export const aiTools = {
   getPortfolioOverview: routedTool({
     telemetryRoutes: ["general"],
@@ -429,5 +434,133 @@ export const aiTools = {
       "Get the Foliofox product reference explaining how the app itself works: CSV import formats and columns, supported broker files (Trade Republic, Scalable Capital, Directa), adding assets, field meanings (quantity, unit value, cost basis per unit, capital gains tax rate), buy/sell/update records, categories, currencies, and sharing. Call this before answering any question about using Foliofox.",
     inputSchema: z.object({}),
     execute: async () => getProductReference(),
+  }),
+
+  getPositionCategories: routedTool({
+    telemetryRoutes: ["general"],
+    description:
+      "List valid position categories: Foliofox system categories plus the user's custom categories. Call this before createPosition to pick a real category id, unless the category is clearly 'other'. Returns: id, name, source (system|custom), category_id, user_category_id, position_type.",
+    inputSchema: z.object({
+      positionType: z
+        .enum(["asset", "liability"])
+        .nullable()
+        .describe("Filter by position type. Leave empty for 'asset'."),
+    }),
+    execute: async (args) => getPositionCategories(args),
+  }),
+
+  createPortfolioRecord: routedTool({
+    telemetryRoutes: ["write"],
+    description:
+      "Create a portfolio record (buy, sell, or update) for an EXISTING position. This modifies the user's portfolio and always requires the user's explicit approval in the chat UI before executing. Use real data gathered from read tools; never invent quantities, prices, or dates. Returns { success } or { success: false, code, message }.",
+    inputSchema: z.object({
+      summary: z
+        .string()
+        .describe(
+          "One-line human-readable description of the action, shown on the user's approval card. Example: 'Buy 20 × AAPL @ 211.50 USD on 2026-07-18'.",
+        ),
+      positionId: z
+        .string()
+        .describe(
+          "Position UUID from getPortfolioOverview or getPositions (positions[].id).",
+        ),
+      type: z
+        .enum(["buy", "sell", "update"])
+        .describe(
+          "'buy' adds quantity, 'sell' removes quantity, 'update' resets quantity and unit value at a date.",
+        ),
+      date: z.string().describe("Record date in YYYY-MM-DD format."),
+      quantity: z
+        .number()
+        .describe(
+          "Units bought/sold, or the new total quantity for 'update' records.",
+        ),
+      unitValue: z
+        .number()
+        .describe("Price per unit in the position's own currency."),
+      description: z
+        .string()
+        .nullable()
+        .describe("Optional note stored on the record."),
+      costBasisPerUnit: z
+        .number()
+        .nullable()
+        .describe(
+          "Only for 'update' records: custom cost basis per unit. Leave empty otherwise.",
+        ),
+    }),
+    execute: async (args) => createPortfolioRecord(args),
+  }),
+
+  createPosition: routedTool({
+    telemetryRoutes: ["write"],
+    description:
+      "Create a NEW position (asset or future liability) with an initial snapshot. Only for holdings not yet tracked; for existing positions use createPortfolioRecord. This modifies the user's portfolio and always requires the user's explicit approval in the chat UI before executing. For market-traded assets provide symbolLookup (confirm the ticker with searchSymbols first); the current market price is used automatically when unitValue is empty. Returns { success } or { success: false, code, message }.",
+    inputSchema: z.object({
+      summary: z
+        .string()
+        .describe(
+          "One-line human-readable description of the action, shown on the user's approval card. Example: 'Add position VWCE.DE: 15 units @ 130.20 EUR (ETFs)'.",
+        ),
+      name: z.string().describe("Position display name, unique per user."),
+      currency: z
+        .string()
+        .describe(
+          "ISO currency code of the position (e.g., USD, EUR). For symbol-linked positions, always use the symbol's trading currency (check searchSymbols/exchange if unsure).",
+        ),
+      type: z
+        .enum(["asset", "liability"])
+        .nullable()
+        .describe("Leave empty for 'asset'."),
+      categoryId: z
+        .string()
+        .nullable()
+        .describe(
+          "System category id from getPositionCategories. Leave empty to use 'other' or when userCategoryId is set.",
+        ),
+      userCategoryId: z
+        .string()
+        .nullable()
+        .describe(
+          "Custom category UUID from getPositionCategories (source 'custom').",
+        ),
+      symbolLookup: z
+        .string()
+        .nullable()
+        .describe(
+          "Yahoo Finance ticker for market-traded assets (e.g., 'AAPL', 'VWCE.DE'). Use searchSymbols first if unsure. Leave empty for custom/manual positions.",
+        ),
+      quantity: z
+        .number()
+        .nullable()
+        .describe("Initial quantity. Leave empty for 0."),
+      unitValue: z
+        .number()
+        .nullable()
+        .describe(
+          "Price per unit in the position currency. Leave empty to use the current market price when symbolLookup is set.",
+        ),
+      costBasisPerUnit: z
+        .number()
+        .nullable()
+        .describe(
+          "Purchase cost per unit. Leave empty to default to the unit value.",
+        ),
+      capitalGainsTaxRate: z
+        .number()
+        .nullable()
+        .describe("Capital gains tax rate percentage (e.g., 26)."),
+      date: z
+        .string()
+        .nullable()
+        .describe(
+          "Initial snapshot date in YYYY-MM-DD format. Leave empty for today.",
+        ),
+      description: z
+        .string()
+        .nullable()
+        .describe("Optional note stored on the position."),
+    }),
+    execute: async (args) => createPosition(args),
   }),
 };

--- a/server/ai/tools/index.ts
+++ b/server/ai/tools/index.ts
@@ -579,6 +579,9 @@ export const aiTools = {
         .nullable()
         .describe("Optional note stored on the position."),
     }),
-    execute: async (args) => createPosition(args),
+    // The stable tool-call id makes a retried approval continuation a no-op
+    // instead of a duplicate position (unique index on idempotency_key).
+    execute: async (args, { toolCallId }) =>
+      createPosition({ ...args, idempotencyKey: toolCallId }),
   }),
 };

--- a/server/ai/tools/index.ts
+++ b/server/ai/tools/index.ts
@@ -469,14 +469,19 @@ export const aiTools = {
         .describe(
           "'buy' adds quantity, 'sell' removes quantity, 'update' resets quantity and unit value at a date.",
         ),
-      date: z.string().describe("Record date in YYYY-MM-DD format."),
+      date: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/)
+        .describe("Record date in YYYY-MM-DD format."),
       quantity: z
         .number()
+        .min(0)
         .describe(
           "Units bought/sold, or the new total quantity for 'update' records.",
         ),
       unitValue: z
         .number()
+        .min(0)
         .describe("Price per unit in the position's own currency."),
       description: z
         .string()
@@ -484,6 +489,7 @@ export const aiTools = {
         .describe("Optional note stored on the record."),
       costBasisPerUnit: z
         .number()
+        .min(0)
         .nullable()
         .describe(
           "Only for 'update' records: custom cost basis per unit. Leave empty otherwise.",
@@ -532,26 +538,32 @@ export const aiTools = {
         ),
       quantity: z
         .number()
+        .min(0)
         .nullable()
         .describe("Initial quantity. Leave empty for 0."),
       unitValue: z
         .number()
+        .min(0)
         .nullable()
         .describe(
           "Price per unit in the position currency. Leave empty to use the current market price when symbolLookup is set.",
         ),
       costBasisPerUnit: z
         .number()
+        .min(0)
         .nullable()
         .describe(
           "Purchase cost per unit. Leave empty to default to the unit value.",
         ),
       capitalGainsTaxRate: z
         .number()
+        .min(0)
+        .max(100)
         .nullable()
-        .describe("Capital gains tax rate percentage (e.g., 26)."),
+        .describe("Capital gains tax rate percentage, 0-100 (e.g., 26)."),
       date: z
         .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/)
         .nullable()
         .describe(
           "Initial snapshot date in YYYY-MM-DD format. Leave empty for today.",

--- a/server/ai/tools/index.ts
+++ b/server/ai/tools/index.ts
@@ -495,7 +495,10 @@ export const aiTools = {
           "Only for 'update' records: custom cost basis per unit. Leave empty otherwise.",
         ),
     }),
-    execute: async (args) => createPortfolioRecord(args),
+    // The stable tool-call id makes a retried approval continuation a no-op
+    // instead of a duplicate record (unique index on idempotency_key).
+    execute: async (args, { toolCallId }) =>
+      createPortfolioRecord({ ...args, idempotencyKey: toolCallId }),
   }),
 
   createPosition: routedTool({

--- a/server/ai/tools/portfolio-overview.test.ts
+++ b/server/ai/tools/portfolio-overview.test.ts
@@ -66,6 +66,7 @@ const createPosition = (
   total_value: 500,
   has_market_data: false,
   capital_gains_tax_rate: null,
+  idempotency_key: null,
   ...overrides,
 });
 

--- a/server/ai/tools/position-categories.ts
+++ b/server/ai/tools/position-categories.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { fetchPositionCategories } from "@/server/position-categories/fetch";
+
+interface GetPositionCategoriesParams {
+  positionType: "asset" | "liability" | null;
+}
+
+/**
+ * List valid position categories (system + the user's custom ones) so the
+ * assistant can pick a real category id before creating a position.
+ */
+export async function getPositionCategories(
+  params: GetPositionCategoriesParams,
+) {
+  const categories = await fetchPositionCategories({
+    positionType: params.positionType ?? "asset",
+    includeCustomCategories: true,
+  });
+
+  return { categories };
+}

--- a/server/ai/tools/positions.test.ts
+++ b/server/ai/tools/positions.test.ts
@@ -50,6 +50,7 @@ const createPosition = (
   total_value: 5000,
   has_market_data: false,
   capital_gains_tax_rate: null,
+  idempotency_key: null,
   ...overrides,
 });
 

--- a/server/analysis/asset-allocation.test.ts
+++ b/server/analysis/asset-allocation.test.ts
@@ -51,6 +51,7 @@ const createPosition = (
   total_value: 100,
   has_market_data: false,
   capital_gains_tax_rate: null,
+  idempotency_key: null,
   ...overrides,
 });
 

--- a/server/analysis/projected-income/portfolio.test.ts
+++ b/server/analysis/projected-income/portfolio.test.ts
@@ -87,6 +87,7 @@ const createPosition = (
   has_market_data: true,
   ...overrides,
   capital_gains_tax_rate: overrides.capital_gains_tax_rate ?? null,
+  idempotency_key: null,
 });
 
 describe("projected income", () => {

--- a/server/portfolio-records/create.test.ts
+++ b/server/portfolio-records/create.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const maybeSingleMock = vi.fn();
+const insertMock = vi.fn();
+
+// Chainable query stub: every filter returns the builder, terminals resolve.
+function createQueryBuilder() {
+  const builder: Record<string, unknown> = {};
+  for (const method of ["select", "eq", "gte", "order", "limit"]) {
+    builder[method] = vi.fn(() => builder);
+  }
+  builder.maybeSingle = maybeSingleMock;
+  builder.insert = insertMock;
+  return builder;
+}
+
+vi.mock("@/server/auth/actions", () => ({
+  getCurrentUser: vi.fn(async () => ({
+    user: { id: "user-1" },
+    supabase: { from: vi.fn(() => createQueryBuilder()) },
+  })),
+}));
+
+vi.mock("@/server/position-snapshots/recalculate", () => ({
+  recalculateSnapshotsUntilNextUpdate: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const { createPortfolioRecord } = await import("./create");
+
+function buildFormData(entries: Record<string, string>) {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    formData.set(key, value);
+  }
+  return formData;
+}
+
+describe("createPortfolioRecord replay handling", () => {
+  beforeEach(() => {
+    maybeSingleMock.mockReset();
+    insertMock.mockReset();
+  });
+
+  it("returns success without inserting when the idempotency key already committed", async () => {
+    maybeSingleMock.mockResolvedValue({ data: { id: "record-1" } });
+
+    const result = await createPortfolioRecord(
+      buildFormData({
+        position_id: "position-1",
+        type: "sell",
+        date: "2026-07-18",
+        quantity: "5",
+        unit_value: "100",
+        idempotency_key: "call_abc123",
+      }),
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/portfolio-records/create.test.ts
+++ b/server/portfolio-records/create.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const maybeSingleMock = vi.fn();
 const insertMock = vi.fn();
+const recalculateMock = vi.fn();
 
 // Chainable query stub: every filter returns the builder, terminals resolve.
 function createQueryBuilder() {
@@ -22,7 +23,7 @@ vi.mock("@/server/auth/actions", () => ({
 }));
 
 vi.mock("@/server/position-snapshots/recalculate", () => ({
-  recalculateSnapshotsUntilNextUpdate: vi.fn(),
+  recalculateSnapshotsUntilNextUpdate: recalculateMock,
 }));
 
 vi.mock("next/cache", () => ({
@@ -43,10 +44,16 @@ describe("createPortfolioRecord replay handling", () => {
   beforeEach(() => {
     maybeSingleMock.mockReset();
     insertMock.mockReset();
+    recalculateMock.mockReset();
+    recalculateMock.mockResolvedValue({ success: true });
   });
 
-  it("returns success without inserting when the idempotency key already committed", async () => {
-    maybeSingleMock.mockResolvedValue({ data: { id: "record-1" } });
+  it("re-runs recalculation for the committed record without re-inserting", async () => {
+    // The first attempt may have died between insert and recalculation, so a
+    // replay must recalculate from the stored record instead of skipping it.
+    maybeSingleMock.mockResolvedValue({
+      data: { id: "record-1", position_id: "position-9", date: "2026-07-10" },
+    });
 
     const result = await createPortfolioRecord(
       buildFormData({
@@ -61,5 +68,34 @@ describe("createPortfolioRecord replay handling", () => {
 
     expect(result).toEqual({ success: true });
     expect(insertMock).not.toHaveBeenCalled();
+    expect(recalculateMock).toHaveBeenCalledWith({
+      positionId: "position-9",
+      fromDate: new Date("2026-07-10"),
+      customCostBasisByRecordId: undefined,
+    });
+  });
+
+  it("preserves a submitted custom cost basis when replaying an update", async () => {
+    maybeSingleMock.mockResolvedValue({
+      data: { id: "record-2", position_id: "position-9", date: "2026-07-10" },
+    });
+
+    await createPortfolioRecord(
+      buildFormData({
+        position_id: "position-1",
+        type: "update",
+        date: "2026-07-18",
+        quantity: "12",
+        unit_value: "80",
+        cost_basis_per_unit: "75.25",
+        idempotency_key: "call_def456",
+      }),
+    );
+
+    expect(recalculateMock).toHaveBeenCalledWith({
+      positionId: "position-9",
+      fromDate: new Date("2026-07-10"),
+      customCostBasisByRecordId: { "record-2": 75.25 },
+    });
   });
 });

--- a/server/portfolio-records/create.ts
+++ b/server/portfolio-records/create.ts
@@ -75,19 +75,58 @@ export async function createPortfolioRecord(formData: FormData) {
     } as const;
   }
 
+  // Recalculation + cache-revalidation tail shared by the fresh-insert path
+  // and the replay paths: the first attempt may have died between insert and
+  // recalculation, so a replay must re-run it (it is idempotent) instead of
+  // reporting success over stale snapshots.
+  async function finalizeRecord(record: {
+    id: string;
+    position_id: string;
+    date: string;
+  }) {
+    const customCostBasisMap =
+      portfolioRecordData.type === "update" && costBasisPerUnit !== null
+        ? { [record.id]: costBasisPerUnit }
+        : undefined;
+
+    const recalculationResult = await recalculateSnapshotsUntilNextUpdate({
+      positionId: record.position_id,
+      fromDate: new Date(record.date),
+      customCostBasisByRecordId: customCostBasisMap,
+    });
+
+    if (!recalculationResult.success) {
+      return {
+        success: false,
+        code: "RECALCULATION_FAILED",
+        message: "Failed to recalculate snapshots after record creation",
+      } as const;
+    }
+
+    revalidatePath("/dashboard", "layout");
+    return { success: true } as const;
+  }
+
+  async function fetchCommittedRecordByIdempotencyKey(key: string) {
+    const { data: existingByKey } = await supabase
+      .from("portfolio_records")
+      .select("id, position_id, date")
+      .eq("user_id", user.id)
+      .eq("idempotency_key", key)
+      .maybeSingle();
+
+    return existingByKey ?? null;
+  }
+
   // Replay check before timeline validation: the committed record from the
   // first attempt is part of the timeline now, so re-validating the candidate
   // would wrongly fail (e.g. INSUFFICIENT_QUANTITY on a replayed full sell).
   if (idempotencyKey !== null) {
-    const { data: existingByKey } = await supabase
-      .from("portfolio_records")
-      .select("id")
-      .eq("user_id", user.id)
-      .eq("idempotency_key", idempotencyKey)
-      .maybeSingle();
+    const committedRecord =
+      await fetchCommittedRecordByIdempotencyKey(idempotencyKey);
 
-    if (existingByKey) {
-      return { success: true } as const;
+    if (committedRecord) {
+      return finalizeRecord(committedRecord);
     }
   }
 
@@ -136,9 +175,15 @@ export async function createPortfolioRecord(formData: FormData) {
 
   if (!inserted || insertError) {
     // Unique violation on the idempotency key means this exact write already
-    // committed (retried approval) — report success without re-inserting.
+    // committed (race with a retry) — finalize the committed record instead
+    // of inserting a duplicate.
     if (idempotencyKey !== null && insertError?.code === "23505") {
-      return { success: true } as const;
+      const committedRecord =
+        await fetchCommittedRecordByIdempotencyKey(idempotencyKey);
+
+      if (committedRecord) {
+        return finalizeRecord(committedRecord);
+      }
     }
 
     return {
@@ -148,26 +193,6 @@ export async function createPortfolioRecord(formData: FormData) {
     } as const;
   }
 
-  const customCostBasisMap =
-    portfolioRecordData.type === "update" && costBasisPerUnit !== null
-      ? { [inserted.id]: costBasisPerUnit }
-      : undefined;
-
   // Recalculate snapshots from this date forward
-  const recalculationResult = await recalculateSnapshotsUntilNextUpdate({
-    positionId: inserted.position_id,
-    fromDate: new Date(inserted.date),
-    customCostBasisByRecordId: customCostBasisMap,
-  });
-
-  if (!recalculationResult.success) {
-    return {
-      success: false,
-      code: "RECALCULATION_FAILED",
-      message: "Failed to recalculate snapshots after record creation",
-    } as const;
-  }
-
-  revalidatePath("/dashboard", "layout");
-  return { success: true } as const;
+  return finalizeRecord(inserted);
 }

--- a/server/portfolio-records/create.ts
+++ b/server/portfolio-records/create.ts
@@ -75,6 +75,22 @@ export async function createPortfolioRecord(formData: FormData) {
     } as const;
   }
 
+  // Replay check before timeline validation: the committed record from the
+  // first attempt is part of the timeline now, so re-validating the candidate
+  // would wrongly fail (e.g. INSUFFICIENT_QUANTITY on a replayed full sell).
+  if (idempotencyKey !== null) {
+    const { data: existingByKey } = await supabase
+      .from("portfolio_records")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("idempotency_key", idempotencyKey)
+      .maybeSingle();
+
+    if (existingByKey) {
+      return { success: true } as const;
+    }
+  }
+
   const { data: affectedRecords, error: affectedRecordsError } = await supabase
     .from("portfolio_records")
     .select("id, position_id, type, date, quantity, created_at")

--- a/server/portfolio-records/create.ts
+++ b/server/portfolio-records/create.ts
@@ -47,6 +47,15 @@ export async function createPortfolioRecord(formData: FormData) {
     description: (formData.get("description") as string) || null,
   };
 
+  // Optional idempotency key (AI-approved writes): a retried approval
+  // continuation re-sends the same key; the partial unique index turns the
+  // duplicate insert into a no-op success instead of a second record.
+  const idempotencyKeyRaw = formData.get("idempotency_key");
+  const idempotencyKey =
+    idempotencyKeyRaw != null && String(idempotencyKeyRaw).trim() !== ""
+      ? String(idempotencyKeyRaw)
+      : null;
+
   // Extract custom cost basis if provided (for UPDATE records)
   const customCostBasis = formData.get("cost_basis_per_unit");
   const costBasisPerUnit =
@@ -101,11 +110,21 @@ export async function createPortfolioRecord(formData: FormData) {
   // Insert portfolio record
   const { data: inserted, error: insertError } = await supabase
     .from("portfolio_records")
-    .insert({ user_id: user.id, ...portfolioRecordData })
+    .insert({
+      user_id: user.id,
+      ...portfolioRecordData,
+      idempotency_key: idempotencyKey,
+    })
     .select("id, position_id, date")
     .single();
 
   if (!inserted || insertError) {
+    // Unique violation on the idempotency key means this exact write already
+    // committed (retried approval) — report success without re-inserting.
+    if (idempotencyKey !== null && insertError?.code === "23505") {
+      return { success: true } as const;
+    }
+
     return {
       success: false,
       code: insertError?.code || "UNKNOWN",

--- a/server/positions/create.test.ts
+++ b/server/positions/create.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const insertMock = vi.fn();
+const resolveSymbolInputMock = vi.fn();
+const createPositionSnapshotMock = vi.fn();
+
+// Chainable query stub: filters return the builder, awaiting it resolves the
+// queued response (one entry per supabase.from() call, in call order).
+const responseQueue: unknown[] = [];
+function createQueryBuilder() {
+  const response = responseQueue.shift() ?? { data: null, error: null };
+  const builder: Record<string, unknown> = {};
+  for (const method of [
+    "select",
+    "eq",
+    "is",
+    "limit",
+    "single",
+    "maybeSingle",
+  ]) {
+    builder[method] = vi.fn(() => builder);
+  }
+  builder.insert = vi.fn((row: unknown) => {
+    insertMock(row);
+    return builder;
+  });
+  builder.then = (resolve: (value: unknown) => unknown) =>
+    Promise.resolve(response).then(resolve);
+  return builder;
+}
+
+vi.mock("@/server/auth/actions", () => ({
+  getCurrentUser: vi.fn(async () => ({
+    user: { id: "user-1" },
+    supabase: { from: vi.fn(() => createQueryBuilder()) },
+  })),
+}));
+
+vi.mock("@/server/symbols/resolve", () => ({
+  resolveSymbolInput: resolveSymbolInputMock,
+}));
+
+vi.mock("@/server/symbols/create", () => ({
+  createSymbol: vi.fn(),
+}));
+
+vi.mock("@/server/position-snapshots/create", () => ({
+  createPositionSnapshot: createPositionSnapshotMock,
+}));
+
+vi.mock("@/server/quotes/fetch", () => ({
+  fetchSingleQuote: vi.fn(async () => 100),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const { createPosition } = await import("./create");
+
+function buildFormData(entries: Record<string, string>) {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    formData.set(key, value);
+  }
+  return formData;
+}
+
+describe("createPosition", () => {
+  beforeEach(() => {
+    insertMock.mockReset();
+    resolveSymbolInputMock.mockReset();
+    createPositionSnapshotMock.mockReset();
+    createPositionSnapshotMock.mockResolvedValue({ success: true });
+    responseQueue.length = 0;
+    // Fresh-create from() order: duplicate-name check, position insert,
+    // existing-snapshot check (finalize).
+    responseQueue.push(
+      { data: [], error: null },
+      { data: { id: "position-1" }, error: null },
+      { data: null, error: null },
+    );
+  });
+
+  it("overrides the submitted currency with the symbol's trading currency", async () => {
+    resolveSymbolInputMock.mockResolvedValue({
+      symbol: { id: "symbol-1", currency: "GBP" },
+    });
+
+    const result = await createPosition(
+      buildFormData({
+        name: "Vodafone",
+        currency: "GBp",
+        symbolLookup: "VOD.L",
+        quantity: "10",
+        unit_value: "72.5",
+        date: "2026-07-18",
+      }),
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ currency: "GBP", symbol_id: "symbol-1" }),
+    );
+  });
+
+  it("keeps the submitted currency for custom positions without a symbol", async () => {
+    const result = await createPosition(
+      buildFormData({
+        name: "Vintage watch",
+        currency: "CHF",
+        quantity: "1",
+        unit_value: "5000",
+        date: "2026-07-18",
+      }),
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(resolveSymbolInputMock).not.toHaveBeenCalled();
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ currency: "CHF", symbol_id: null }),
+    );
+  });
+
+  it("replays an idempotent create as a success without re-inserting", async () => {
+    responseQueue.length = 0;
+    // 1st from(): committed-position lookup by key, 2nd from(): the
+    // existing-snapshot check inside finalize.
+    responseQueue.push(
+      { data: { id: "position-9", symbol_id: null }, error: null },
+      { data: { id: "snapshot-1" }, error: null },
+    );
+
+    const result = await createPosition(
+      buildFormData({
+        name: "Vintage watch",
+        currency: "CHF",
+        quantity: "1",
+        unit_value: "5000",
+        date: "2026-07-18",
+        idempotency_key: "call_abc123",
+      }),
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(createPositionSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("re-creates the missing initial snapshot when replaying a half-committed create", async () => {
+    responseQueue.length = 0;
+    // Committed position exists but the first attempt died before the
+    // snapshot write: the replay must write it, not just report success.
+    responseQueue.push(
+      { data: { id: "position-9", symbol_id: null }, error: null },
+      { data: null, error: null },
+    );
+
+    const result = await createPosition(
+      buildFormData({
+        name: "Vintage watch",
+        currency: "CHF",
+        quantity: "1",
+        unit_value: "5000",
+        date: "2026-07-18",
+        idempotency_key: "call_abc123",
+      }),
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(createPositionSnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        position_id: "position-9",
+        quantity: 1,
+        unit_value: 5000,
+      }),
+    );
+  });
+});

--- a/server/positions/create.ts
+++ b/server/positions/create.ts
@@ -42,7 +42,7 @@ export async function createPosition(formData: FormData) {
 
   // Required fields
   const name = (formData.get("name") as string) || "";
-  const currency = (formData.get("currency") as string) || "";
+  let currency = (formData.get("currency") as string) || "";
   const categorySelection = resolvePositionCategorySelection(formData);
   const type = (formData.get("type") as Position["type"]) || "asset";
   const description = (formData.get("description") as string) || null;
@@ -64,6 +64,15 @@ export async function createPosition(formData: FormData) {
   let symbolUuid: string | null = null;
   const domainId = (formData.get("domain_id") as string) || null;
 
+  // Optional idempotency key (AI-approved writes): a retried approval
+  // continuation re-sends the same key; the replay paths below turn the
+  // duplicate create into a success for the already-committed position.
+  const idempotencyKeyRaw = formData.get("idempotency_key");
+  const idempotencyKey =
+    idempotencyKeyRaw != null && String(idempotencyKeyRaw).trim() !== ""
+      ? String(idempotencyKeyRaw)
+      : null;
+
   // Initial snapshot fields
   const quantityRaw = formData.get("quantity");
   const unitValueRaw = formData.get("unit_value");
@@ -72,7 +81,7 @@ export async function createPosition(formData: FormData) {
   const dateRaw = (formData.get("date") as string) || null;
 
   const quantity = quantityRaw != null ? Number(quantityRaw) : 0;
-  let unit_value: number | null =
+  const unit_value: number | null =
     unitValueRaw != null && String(unitValueRaw).trim() !== ""
       ? Number(unitValueRaw)
       : null;
@@ -86,6 +95,94 @@ export async function createPosition(formData: FormData) {
       : null;
   const snapshotDate = dateRaw ? new Date(dateRaw) : new Date();
 
+  async function fetchCommittedPositionByIdempotencyKey(key: string) {
+    const { data: existingByKey } = await supabase
+      .from("positions")
+      .select("id, symbol_id")
+      .eq("user_id", user.id)
+      .eq("idempotency_key", key)
+      .maybeSingle();
+
+    return existingByKey ?? null;
+  }
+
+  // Initial-snapshot + cache-revalidation tail shared by the fresh-insert
+  // path and the replay paths: the first attempt may have died between the
+  // position insert and the snapshot write, so a replay re-creates a missing
+  // snapshot (it is skipped when one already exists) instead of reporting
+  // success over a half-created position.
+  async function finalizePosition(position: {
+    id: string;
+    symbol_id: string | null;
+  }) {
+    const { data: existingSnapshot } = await supabase
+      .from("position_snapshots")
+      .select("id")
+      .eq("position_id", position.id)
+      .limit(1)
+      .maybeSingle();
+
+    if (existingSnapshot) {
+      revalidatePath("/dashboard", "layout");
+      return { success: true } as const;
+    }
+
+    let resolvedUnitValue = unit_value;
+    if (
+      position.symbol_id &&
+      (resolvedUnitValue == null || Number.isNaN(resolvedUnitValue))
+    ) {
+      try {
+        // Avoid seeding cooldown during create so the immediate dashboard render
+        // can retry live quote repair if this bootstrap read returns no data.
+        resolvedUnitValue = await fetchSingleQuote(position.symbol_id, {
+          upsert: true,
+          liveMissCooldownMinutes: 0,
+        });
+      } catch (error) {
+        console.warn(
+          `Failed to fetch canonical price for symbol ${position.symbol_id}:`,
+          error,
+        );
+        resolvedUnitValue = null;
+      }
+    }
+
+    const finalUnitValue =
+      resolvedUnitValue != null && Number.isFinite(resolvedUnitValue)
+        ? resolvedUnitValue
+        : 0;
+    const finalCostBasis =
+      costBasisInput != null && Number.isFinite(costBasisInput)
+        ? costBasisInput
+        : finalUnitValue;
+
+    const snapshotResult = await createPositionSnapshot({
+      position_id: position.id,
+      date: formatUTCDateKey(snapshotDate),
+      quantity,
+      unit_value: finalUnitValue,
+      cost_basis_per_unit: finalCostBasis,
+    });
+
+    if (!snapshotResult.success) return snapshotResult;
+
+    revalidatePath("/dashboard", "layout");
+    return { success: true } as const;
+  }
+
+  // Replay check before the duplicate-name check: the committed position from
+  // the first attempt carries this same name, so re-validating it would
+  // wrongly fail with DUPLICATE_NAME.
+  if (idempotencyKey !== null) {
+    const committedPosition =
+      await fetchCommittedPositionByIdempotencyKey(idempotencyKey);
+
+    if (committedPosition) {
+      return finalizePosition(committedPosition);
+    }
+  }
+
   // Duplicate name check (active positions only)
   const isDuplicate = await checkDuplicatePositionName(name, user.id);
   if (isDuplicate) {
@@ -98,11 +195,9 @@ export async function createPosition(formData: FormData) {
 
   // Ensure symbol exists if provided
   if (rawSymbolInput) {
-    const resolved = await resolveSymbolInput(rawSymbolInput);
+    let resolved = await resolveSymbolInput(rawSymbolInput);
 
-    if (resolved?.symbol?.id) {
-      symbolUuid = resolved.symbol.id;
-    } else {
+    if (!resolved?.symbol?.id) {
       const creationResult = await createSymbol(rawSymbolInput);
       if (!creationResult.success || !creationResult.data?.id) {
         return {
@@ -114,8 +209,8 @@ export async function createPosition(formData: FormData) {
         } as const;
       }
 
-      const postCreateResolved = await resolveSymbolInput(rawSymbolInput);
-      if (!postCreateResolved?.symbol?.id) {
+      resolved = await resolveSymbolInput(rawSymbolInput);
+      if (!resolved?.symbol?.id) {
         return {
           success: false,
           code: "SYMBOL_RESOLUTION_FAILED",
@@ -123,34 +218,14 @@ export async function createPosition(formData: FormData) {
             "Symbol metadata was created but could not be resolved to a canonical identifier.",
         } as const;
       }
-
-      symbolUuid = postCreateResolved.symbol.id;
     }
 
-    if (symbolUuid && (unit_value == null || Number.isNaN(unit_value))) {
-      try {
-        // Avoid seeding cooldown during create so the immediate dashboard render
-        // can retry live quote repair if this bootstrap read returns no data.
-        unit_value = await fetchSingleQuote(symbolUuid, {
-          upsert: true,
-          liveMissCooldownMinutes: 0,
-        });
-      } catch (error) {
-        console.warn(
-          `Failed to fetch canonical price for symbol ${symbolUuid}:`,
-          error,
-        );
-        unit_value = null;
-      }
-    }
+    symbolUuid = resolved.symbol.id;
+    // Symbol-linked positions must use the symbol's normalized trading
+    // currency (e.g. GBp -> GBP): callers like the AI write tool may pass a
+    // different code, which would skew every later valuation and FX step.
+    currency = resolved.symbol.currency;
   }
-
-  const finalUnitValue =
-    unit_value != null && Number.isFinite(unit_value) ? unit_value : 0;
-  const finalCostBasis =
-    costBasisInput != null && Number.isFinite(costBasisInput)
-      ? costBasisInput
-      : finalUnitValue;
 
   // Create position
   const { data: positionRow, error: positionError } = await supabase
@@ -166,11 +241,24 @@ export async function createPosition(formData: FormData) {
       symbol_id: symbolUuid,
       domain_id: domainId,
       capital_gains_tax_rate: capitalGainsTaxRate,
+      idempotency_key: idempotencyKey,
     })
     .select("id")
     .single();
 
   if (!positionRow || positionError) {
+    // Unique violation on the idempotency key means this exact create already
+    // committed (race with a retry) — finalize the committed position instead
+    // of failing on the duplicate insert.
+    if (idempotencyKey !== null && positionError?.code === "23505") {
+      const committedPosition =
+        await fetchCommittedPositionByIdempotencyKey(idempotencyKey);
+
+      if (committedPosition) {
+        return finalizePosition(committedPosition);
+      }
+    }
+
     return {
       success: false,
       code: positionError?.code || "POSITION_CREATE_FAILED",
@@ -178,17 +266,6 @@ export async function createPosition(formData: FormData) {
     } as const;
   }
 
-  // Initial snapshot via helper (synthetic)
-  const snapshotResult = await createPositionSnapshot({
-    position_id: positionRow.id,
-    date: formatUTCDateKey(snapshotDate),
-    quantity,
-    unit_value: finalUnitValue,
-    cost_basis_per_unit: finalCostBasis,
-  });
-
-  if (!snapshotResult.success) return snapshotResult;
-
-  revalidatePath("/dashboard", "layout");
-  return { success: true } as const;
+  // Initial snapshot (synthetic) + cache revalidation
+  return finalizePosition({ id: positionRow.id, symbol_id: symbolUuid });
 }

--- a/server/positions/export.test.ts
+++ b/server/positions/export.test.ts
@@ -47,6 +47,7 @@ const createPosition = (
   total_value: 5000,
   has_market_data: false,
   capital_gains_tax_rate: null,
+  idempotency_key: null,
   ...overrides,
 });
 

--- a/supabase/migrations/20260719142807_allow_update_own_ai_turn_events_for_upsert.sql
+++ b/supabase/migrations/20260719142807_allow_update_own_ai_turn_events_for_upsert.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+-- UNIQUE (assistant_message_id) already exists from the create migration
+-- (20260227032421), so telemetry upserts on it directly. What was missing is
+-- RLS: the table only had SELECT and INSERT policies, so the ON CONFLICT DO
+-- UPDATE path (tool-approval continuations re-reporting the same assistant
+-- message) would be rejected.
+
+DO $$
+BEGIN
+  CREATE POLICY "Users can update own AI turn events"
+    ON public.ai_assistant_turn_events
+    FOR UPDATE
+    TO authenticated
+    USING (user_id = (select auth.uid()))
+    WITH CHECK (user_id = (select auth.uid()));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+COMMENT ON CONSTRAINT ai_assistant_turn_events_assistant_message_id_key
+  ON public.ai_assistant_turn_events IS
+  'One telemetry event per assistant message; approval continuations upsert into the same row.';
+
+COMMIT;

--- a/supabase/migrations/20260719152953_add_portfolio_records_idempotency_key.sql
+++ b/supabase/migrations/20260719152953_add_portfolio_records_idempotency_key.sql
@@ -1,0 +1,11 @@
+-- Idempotency key for AI-approved portfolio record writes.
+-- A retried approval continuation (lost response + client resend) re-executes
+-- the same tool call with the same tool-call id; the partial unique index makes
+-- the second insert fail instead of silently duplicating the record.
+-- Forms, CSV import, and broker import leave the key NULL and are unaffected.
+ALTER TABLE "public"."portfolio_records"
+ADD COLUMN IF NOT EXISTS "idempotency_key" text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "portfolio_records_user_idempotency_key_idx"
+ON "public"."portfolio_records" ("user_id", "idempotency_key")
+WHERE "idempotency_key" IS NOT NULL;

--- a/supabase/migrations/20260720050533_add_positions_idempotency_key.sql
+++ b/supabase/migrations/20260720050533_add_positions_idempotency_key.sql
@@ -1,0 +1,12 @@
+-- Idempotency key for AI-approved position creation.
+-- A retried approval continuation (lost response + client resend) re-executes
+-- the same tool call with the same tool-call id; the partial unique index makes
+-- the second insert fail instead of duplicating the position (the replay path
+-- then returns the committed position as a success).
+-- Forms, CSV import, and broker import leave the key NULL and are unaffected.
+ALTER TABLE "public"."positions"
+ADD COLUMN IF NOT EXISTS "idempotency_key" text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "positions_user_idempotency_key_idx"
+ON "public"."positions" ("user_id", "idempotency_key")
+WHERE "idempotency_key" IS NOT NULL;

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -7,6 +7,11 @@ export type Json =
   | Json[]
 
 export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.5"
+  }
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -719,6 +724,7 @@ export type Database = {
           description: string | null
           domain_id: string | null
           id: string
+          idempotency_key: string | null
           name: string
           symbol_id: string | null
           type: Database["public"]["Enums"]["position_type"]
@@ -735,6 +741,7 @@ export type Database = {
           description?: string | null
           domain_id?: string | null
           id?: string
+          idempotency_key?: string | null
           name: string
           symbol_id?: string | null
           type: Database["public"]["Enums"]["position_type"]
@@ -751,6 +758,7 @@ export type Database = {
           description?: string | null
           domain_id?: string | null
           id?: string
+          idempotency_key?: string | null
           name?: string
           symbol_id?: string | null
           type?: Database["public"]["Enums"]["position_type"]
@@ -1262,4 +1270,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -7,11 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.5"
-  }
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -587,6 +582,7 @@ export type Database = {
           description: string | null
           external_transaction_id: string | null
           id: string
+          idempotency_key: string | null
           import_source: string | null
           position_id: string
           quantity: number
@@ -601,6 +597,7 @@ export type Database = {
           description?: string | null
           external_transaction_id?: string | null
           id?: string
+          idempotency_key?: string | null
           import_source?: string | null
           position_id: string
           quantity: number
@@ -615,6 +612,7 @@ export type Database = {
           description?: string | null
           external_transaction_id?: string | null
           id?: string
+          idempotency_key?: string | null
           import_source?: string | null
           position_id?: string
           quantity?: number
@@ -1264,3 +1262,4 @@ export const Constants = {
     },
   },
 } as const
+


### PR DESCRIPTION
## Summary

Gives the AI advisor the ability to write to the portfolio — record a buy/sell/update on an
existing position, or create a new position (asset or future liability) — behind an explicit
per-write user approval. Nothing reaches the database until the user presses Approve in the chat.

## How it works

1. The model calls `createPortfolioRecord` or `createPosition`. Both are registered as
   `"user-approval"` in `toolApproval` on the chat route, so the SDK suspends the tool call
   instead of executing it.
2. The chat renders a Confirmation card with a plain-language `summary` of exactly what will
   happen. The composer is blocked while an approval is pending — an unanswered approval would
   leave a dangling tool call and break the next model request.
3. On approve, the tool executes through the same server path as the regular forms, so record
   timeline checks, oversell protection, duplicate-name checks, and snapshot recalculation all
   apply. On deny, the write is discarded and the system prompt tells the model not to retry.
4. After a successful write the dashboard RSC data is refreshed.

## Safety

- **Signed approvals** — `experimental_toolApprovalSecret` (`TOOL_APPROVAL_SECRET`) prevents a
  tampered client from altering write-tool inputs between propose and approve. A missing secret
  is warned about once, loudly, in production.
- **Idempotency** — approved writes carry an idempotency key derived from the tool-call id, with
  a partial unique index on `(user_id, idempotency_key)`. A retried approval continuation (lost
  response + client resend) fails the duplicate insert instead of silently creating a second
  record. A replayed insert recalculates snapshots so the outcome matches a first-time write.
  Forms, CSV import, and broker import leave the key NULL and are unaffected.
- **Scope limits** — the advisor cannot delete or archive positions, edit or delete existing
  records, or run imports.
- The model is instructed to resolve real position ids and look up market prices rather than
  invent values, and to propose one write at a time.

## Migrations

- `..._add_portfolio_records_idempotency_key.sql` — nullable `idempotency_key` column + partial
  unique index.
- `..._allow_update_own_ai_turn_events_for_upsert.sql` — adds the missing RLS UPDATE policy on
  `ai_assistant_turn_events`; approval continuations upsert into the same telemetry row per
  assistant message, and without it the `ON CONFLICT DO UPDATE` path was rejected.

## Telemetry

Turn events now classify a `write` route and a committed-write outcome, deduped per assistant
message across the approval round-trip.

## Testing

Unit tests cover the write tools' input mapping, the create path's idempotent replay and snapshot
recalculation, the chat route's approval wiring, the pending-approval composer block, and the
telemetry route/outcome resolution.

## Docs

`content/product-reference.md` gains an "AI advisor portfolio updates" section so the advisor can
answer questions about its own write capability.