### PR TITLE
feat(symbols): Symbol ticker reuse support and active alias resolution

### DIFF
--- a/components/dashboard/positions/asset/stale-badge.test.tsx
+++ b/components/dashboard/positions/asset/stale-badge.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { useDashboardDataMock } = vi.hoisted(() => ({
   useDashboardDataMock: vi.fn(),
@@ -55,6 +55,8 @@ vi.mock("@/components/dashboard/positions/shared/archive-dialog", () => ({
 import { StaleBadge } from "./stale-badge";
 
 describe("StaleBadge", () => {
+  afterEach(cleanup);
+
   beforeEach(() => {
     useDashboardDataMock.mockReturnValue({
       marketDataStatuses: [
@@ -68,14 +70,21 @@ describe("StaleBadge", () => {
     });
   });
 
+  it("renders icon-only in table rows when no label is passed", () => {
+    render(<StaleBadge positionId="position-1" />);
+
+    expect(screen.queryByText("No market data")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Market data unavailable" }),
+    ).toBeTruthy();
+  });
+
   it("offers symbol-update and archive paths for unavailable market data", () => {
     render(<StaleBadge positionId="position-1" label="Stale" />);
 
-    expect(screen.getByText("Market data unavailable")).toBeTruthy();
+    expect(screen.getByText("No market data")).toBeTruthy();
     expect(
-      screen.getByText(
-        /Change the ticker if it moved, or archive the position/,
-      ),
+      screen.getByText(/No live price — showing the last saved value/),
     ).toBeTruthy();
 
     fireEvent.click(
@@ -97,5 +106,25 @@ describe("StaleBadge", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Archive Position" }));
     expect(screen.getByText("Archive Old Holding")).toBeTruthy();
+  });
+
+  it("keeps the yellow stale treatment with its own tooltip", () => {
+    useDashboardDataMock.mockReturnValue({
+      marketDataStatuses: [
+        {
+          positionId: "position-1",
+          positionName: "Live Holding",
+          ticker: "LIVE",
+          status: "stale",
+        },
+      ],
+    });
+
+    render(<StaleBadge positionId="position-1" label="Stale" />);
+
+    expect(screen.getByText("Stale")).toBeTruthy();
+    expect(
+      screen.getByText(/Price data hasn't updated in over 7 days/),
+    ).toBeTruthy();
   });
 });

--- a/components/dashboard/positions/asset/stale-badge.test.tsx
+++ b/components/dashboard/positions/asset/stale-badge.test.tsx
@@ -83,9 +83,7 @@ describe("StaleBadge", () => {
     render(<StaleBadge positionId="position-1" label="Stale" />);
 
     expect(screen.getByText("No market data")).toBeTruthy();
-    expect(
-      screen.getByText(/No live price — showing the last saved value/),
-    ).toBeTruthy();
+    expect(screen.getByText(/showing the last saved value/)).toBeTruthy();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Market data unavailable" }),

--- a/components/dashboard/positions/asset/stale-badge.tsx
+++ b/components/dashboard/positions/asset/stale-badge.tsx
@@ -48,7 +48,12 @@ export function StaleBadge({ positionId, label }: StaleBadgeProps) {
   if (!marketDataStatus) return null;
 
   const isUnavailable = marketDataStatus.status === "unavailable";
-  const badgeLabel = isUnavailable ? "Market data unavailable" : label;
+  // Icon-only when no label is passed (table rows); short label elsewhere.
+  const badgeLabel = label
+    ? isUnavailable
+      ? "No market data"
+      : label
+    : undefined;
 
   const handleUpdateSymbolSuccess = () => {
     setStatusDialogOpen(false);
@@ -83,17 +88,14 @@ export function StaleBadge({ positionId, label }: StaleBadgeProps) {
 
   return (
     <>
-      {isUnavailable ? (
-        <Tooltip>
-          <TooltipTrigger asChild>{badge}</TooltipTrigger>
-          <TooltipContent>
-            Automatic market data is unavailable. Change the ticker if it moved,
-            or archive the position if you no longer hold it.
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        badge
-      )}
+      <Tooltip>
+        <TooltipTrigger asChild>{badge}</TooltipTrigger>
+        <TooltipContent>
+          {isUnavailable
+            ? "No live price - showing the last saved value. Click for options."
+            : "Price data hasn't updated in over 7 days. Click for details."}
+        </TooltipContent>
+      </Tooltip>
 
       <Dialog open={statusDialogOpen} onOpenChange={setStatusDialogOpen}>
         <DialogContent>

--- a/content/product-reference.md
+++ b/content/product-reference.md
@@ -10,6 +10,8 @@
   - public/sample-positions-template.csv, public/sample-records-template.csv
   - lib/import/broker-transactions/registry.ts + adapters/ (supported brokers)
   - components/dashboard/new-asset/forms/ (add-asset paths + field rules)
+  - server/symbols/create.ts, server/symbols/resolve.ts (active listing resolution + ticker reuse)
+  - server/positions/create.ts, server/positions/import.ts, server/positions/update-symbol.ts (symbol association)
   - components/dashboard/new-portfolio-record/forms/ (buy/sell/update rules)
   - server/portfolio-records/create.ts (record semantics + snapshot recalculation)
   - server/ai/tools/create-portfolio-record.ts, server/ai/tools/create-position.ts (AI advisor write tools)
@@ -62,6 +64,8 @@ Three ways to add an asset:
 **Cash and single items:** either set quantity to the balance with unit value 1 (e.g. quantity 5000, unit value 1), or quantity 1 with unit value equal to the total (e.g. a house: quantity 1, unit value 8,200,000). Both work; total value = quantity × unit value.
 
 **Position value** = quantity × unit value. **Profit/loss** = (unit value − cost basis per unit) × quantity, computed from the latest relevant snapshot.
+
+Symbol-linked additions, imports, and ticker updates resolve only active Yahoo Finance listings. A retired or delisted ticker is never silently attached to its historical security: Foliofox attempts to create the current Yahoo listing and, if Yahoo no longer provides it, returns an error so the ticker can be corrected or the asset entered manually.
 
 ### Market data status
 
@@ -116,6 +120,7 @@ Import behaviors worth knowing:
 
 - For rows in the `cryptocurrency` category, a plain coin code is normalized to Yahoo format with USD ("BTC" → "BTC-USD") and the currency is set to USD. Outside that category this does not happen — for a bare coin symbol without a crypto category, use the full pair (e.g. `BTC-USD`) yourself, since a symbol with no category is otherwise treated as equity.
 - If a symbol's listing currency differs from the CSV's currency, the import adjusts to the symbol's currency (or reports an error asking you to fix the row).
+- `symbol_lookup` must resolve to an active Yahoo Finance listing. Retired or delisted tickers fail the import instead of linking the row to a historical security that once used that ticker.
 - Prices quoted in pence/fils (GBX/GBp) are converted to the ISO currency (GBP) automatically.
 
 Example rows:

--- a/docs/SYMBOL-RENAME-HANDLING.md
+++ b/docs/SYMBOL-RENAME-HANDLING.md
@@ -49,7 +49,23 @@ Changing a position symbol affects future quote lookups only. Historical records
 - UUID-based canonical resolution and inactive display fallback keep cached
   historical data readable after retirement.
 
-### 5) Final lifecycle stage: orphan symbol cleanup
+### 5) Ticker reuse and canonical identity
+
+- `symbols.id` is the durable identity. `symbols.ticker` is display metadata and
+  is not used to decide which canonical symbol owns a current ticker.
+- Active aliases are unique by `(source, type, value)`. Alias values written by
+  the application are trimmed and uppercased.
+- Non-UUID ticker resolution chooses an active alias first, then the requested
+  source (or Yahoo for source-unspecified ticker lookups), primary status, the
+  most recent effective/retired timestamp, and alias UUID.
+- Creating or refreshing a position, importing a current position, updating a
+  position symbol, and resolving broker tickers require an active Yahoo ticker
+  alias. A ticker that exists only in retired history therefore creates a new
+  canonical UUID when Yahoo reuses it.
+- Explicit symbol UUIDs continue to resolve the original canonical symbol, so
+  cached quotes and position history remain attached to the old security.
+
+### 6) Final lifecycle stage: orphan symbol cleanup
 
 - The `symbols_cleanup` pg_cron job from migration
   `20251115073138_news_and_symbols_cleanup_pg_cron_jobs.sql` runs at 03:00 UTC

--- a/docs/SYMBOL-RENAME-HANDLING.md
+++ b/docs/SYMBOL-RENAME-HANDLING.md
@@ -53,8 +53,9 @@ Changing a position symbol affects future quote lookups only. Historical records
 
 - `symbols.id` is the durable identity. `symbols.ticker` is display metadata and
   is not used to decide which canonical symbol owns a current ticker.
-- Active aliases are unique by `(source, type, value)`. Alias values written by
-  the application are trimmed and uppercased.
+- Active ticker aliases are unique by `(source, value)`. ISIN aliases may map
+  one security to multiple listings. Alias values written by the application
+  are trimmed and uppercased.
 - Non-UUID ticker resolution chooses an active alias first, then the requested
   source (or Yahoo for source-unspecified ticker lookups), primary status, the
   most recent effective/retired timestamp, and alias UUID.

--- a/docs/production-logs-remediations/production-logs-remediation-jul-22-2026.md
+++ b/docs/production-logs-remediations/production-logs-remediation-jul-22-2026.md
@@ -61,7 +61,7 @@ Deployment order:
 - Use one deterministic alias rule: active first, requested source next, Yahoo preferred for source-unspecified tickers, then primary, most recently effective/retired, and alias ID.
 - Migration:
   - drop `symbols_ticker_key`;
-  - add a unique partial index on `(source, type, value) WHERE effective_to IS NULL`;
+  - add a unique partial index on `(source, value) WHERE type = 'ticker' AND effective_to IS NULL`;
   - use plain normalized `value`, without `lower()`;
   - roll back and report active duplicates instead of auto-merging them.
 - Replace ticker upsert in `createSymbol()`:

--- a/server/import/broker-transactions/instrument-resolution.test.ts
+++ b/server/import/broker-transactions/instrument-resolution.test.ts
@@ -84,6 +84,7 @@ describe("broker instrument resolution", () => {
     expect(resolveSymbolInputMock).toHaveBeenCalledWith("US0000000001", {
       type: "isin",
       source: "trade_republic",
+      activeOnly: true,
     });
     expect(upsertSymbolAliasMock).toHaveBeenCalledWith(
       "symbol-1",
@@ -314,6 +315,44 @@ describe("broker instrument resolution", () => {
       warning: expect.stringContaining("none are quoted in EUR"),
     });
     expect(createSymbolMock).not.toHaveBeenCalled();
+  });
+
+  it("links broker tickers only through active Yahoo aliases", async () => {
+    const tickerPosition: BrokerTransactionPositionDraft = {
+      ...basePosition,
+      positionKey: "trade_republic:acme:acme",
+      brokerSymbol: "ACME",
+      currency: "USD",
+    };
+    resolveSymbolInputMock.mockResolvedValue({
+      symbol: {
+        id: "symbol-active",
+        ticker: "ACME",
+        currency: "USD",
+        long_name: "Acme",
+        short_name: "Acme",
+        exchange: "NYQ",
+      },
+    });
+
+    const { resolveBrokerTransactionInstruments } =
+      await import("./instrument-resolution");
+    const result = await resolveBrokerTransactionInstruments({
+      positions: [tickerPosition],
+      importSource: "trade_republic",
+    });
+
+    expect(result.get(tickerPosition.positionKey)).toMatchObject({
+      state: "auto_linked",
+      symbolId: "symbol-active",
+      selectedTicker: "ACME",
+    });
+    expect(resolveSymbolInputMock).toHaveBeenCalledWith("ACME", {
+      type: "ticker",
+      source: "yahoo",
+      activeOnly: true,
+    });
+    expect(searchYahooFinanceSymbolsMock).not.toHaveBeenCalled();
   });
 
   it("accepts a user-selected different-currency symbol for FX conversion", async () => {

--- a/server/import/broker-transactions/instrument-resolution.ts
+++ b/server/import/broker-transactions/instrument-resolution.ts
@@ -135,7 +135,8 @@ async function resolveBrokerTransactionInstrument(options: {
     type: aliasType,
     // ISIN aliases are broker-scoped because an ISIN identifies the security,
     // not the venue/currency-specific market listing we attach to positions.
-    source: isIsin ? importSource : undefined,
+    source: isIsin ? importSource : "yahoo",
+    activeOnly: true,
   });
 
   if (existing?.symbol && !isIsin) {

--- a/server/positions/create.test.ts
+++ b/server/positions/create.test.ts
@@ -99,6 +99,11 @@ describe("createPosition", () => {
     );
 
     expect(result).toEqual({ success: true });
+    expect(resolveSymbolInputMock).toHaveBeenCalledWith("VOD.L", {
+      source: "yahoo",
+      type: "ticker",
+      activeOnly: true,
+    });
     expect(insertMock).toHaveBeenCalledWith(
       expect.objectContaining({ currency: "GBP", symbol_id: "symbol-1" }),
     );

--- a/server/positions/create.ts
+++ b/server/positions/create.ts
@@ -195,7 +195,11 @@ export async function createPosition(formData: FormData) {
 
   // Ensure symbol exists if provided
   if (rawSymbolInput) {
-    let resolved = await resolveSymbolInput(rawSymbolInput);
+    let resolved = await resolveSymbolInput(rawSymbolInput, {
+      source: "yahoo",
+      type: "ticker",
+      activeOnly: true,
+    });
 
     if (!resolved?.symbol?.id) {
       const creationResult = await createSymbol(rawSymbolInput);
@@ -209,7 +213,11 @@ export async function createPosition(formData: FormData) {
         } as const;
       }
 
-      resolved = await resolveSymbolInput(rawSymbolInput);
+      resolved = await resolveSymbolInput(rawSymbolInput, {
+        source: "yahoo",
+        type: "ticker",
+        activeOnly: true,
+      });
       if (!resolved?.symbol?.id) {
         return {
           success: false,

--- a/server/positions/import.ts
+++ b/server/positions/import.ts
@@ -69,7 +69,11 @@ export async function importPositionsFromCSV(
       const rawSymbolInput = row.symbolLookup?.trim() ?? "";
 
       if (rawSymbolInput !== "") {
-        const resolved = await resolveSymbolInput(rawSymbolInput);
+        const resolved = await resolveSymbolInput(rawSymbolInput, {
+          source: "yahoo",
+          type: "ticker",
+          activeOnly: true,
+        });
 
         if (resolved?.symbol?.id) {
           canonicalSymbolId = resolved.symbol.id;
@@ -82,7 +86,11 @@ export async function importPositionsFromCSV(
             };
           }
 
-          const postCreateResolved = await resolveSymbolInput(rawSymbolInput);
+          const postCreateResolved = await resolveSymbolInput(rawSymbolInput, {
+            source: "yahoo",
+            type: "ticker",
+            activeOnly: true,
+          });
           if (!postCreateResolved?.symbol?.id) {
             return {
               success: false,

--- a/server/positions/update-symbol.ts
+++ b/server/positions/update-symbol.ts
@@ -71,7 +71,11 @@ export async function updatePositionSymbol(
 
   // 4) Resolve symbol input (create if missing)
   let symbol: Symbol | null = null;
-  const resolved = await resolveSymbolInput(trimmedLookup);
+  const resolved = await resolveSymbolInput(trimmedLookup, {
+    source: "yahoo",
+    type: "ticker",
+    activeOnly: true,
+  });
 
   if (resolved?.symbol?.id) {
     symbol = resolved.symbol;

--- a/server/symbols/create.test.ts
+++ b/server/symbols/create.test.ts
@@ -4,6 +4,7 @@ const {
   getCurrentUserMock,
   fetchYahooFinanceSymbolMock,
   fetchCurrenciesMock,
+  resolveSymbolInputMock,
   setPrimarySymbolAliasMock,
   createServiceClientMock,
   fetchQuotesMock,
@@ -11,6 +12,7 @@ const {
   getCurrentUserMock: vi.fn(),
   fetchYahooFinanceSymbolMock: vi.fn(),
   fetchCurrenciesMock: vi.fn(),
+  resolveSymbolInputMock: vi.fn(),
   setPrimarySymbolAliasMock: vi.fn(),
   createServiceClientMock: vi.fn(),
   fetchQuotesMock: vi.fn(),
@@ -29,6 +31,7 @@ vi.mock("@/server/currencies/fetch", () => ({
 }));
 
 vi.mock("@/server/symbols/resolve", () => ({
+  resolveSymbolInput: resolveSymbolInputMock,
   setPrimarySymbolAlias: setPrimarySymbolAliasMock,
 }));
 
@@ -42,13 +45,14 @@ vi.mock("@/server/quotes/fetch", () => ({
 
 function createSupabaseStub() {
   const state = {
-    upsertRows: [] as Array<Record<string, unknown>>,
+    insertRows: [] as Array<Record<string, unknown>>,
+    updateRows: [] as Array<Record<string, unknown>>,
+    updatedIds: [] as string[],
   };
 
   const symbolsApi = {
-    upsert(row: Record<string, unknown>) {
-      state.upsertRows.push({ ...row });
-
+    insert(row: Record<string, unknown>) {
+      state.insertRows.push({ ...row });
       return {
         select() {
           return {
@@ -59,6 +63,27 @@ function createSupabaseStub() {
                   ...row,
                 },
                 error: null,
+              };
+            },
+          };
+        },
+      };
+    },
+    update(row: Record<string, unknown>) {
+      state.updateRows.push({ ...row });
+      return {
+        eq(column: string, value: string) {
+          expect(column).toBe("id");
+          state.updatedIds.push(value);
+          return {
+            select() {
+              return {
+                async single() {
+                  return {
+                    data: { id: value, ...row },
+                    error: null,
+                  };
+                },
               };
             },
           };
@@ -86,6 +111,7 @@ describe("createSymbol", () => {
     getCurrentUserMock.mockReset();
     fetchYahooFinanceSymbolMock.mockReset();
     fetchCurrenciesMock.mockReset();
+    resolveSymbolInputMock.mockReset();
     setPrimarySymbolAliasMock.mockReset();
     createServiceClientMock.mockReset();
     fetchQuotesMock.mockReset();
@@ -96,6 +122,7 @@ describe("createSymbol", () => {
       { alphabetic_code: "GBP", name: "Pound Sterling" },
       { alphabetic_code: "KWD", name: "Kuwaiti Dinar" },
     ]);
+    resolveSymbolInputMock.mockResolvedValue(null);
     setPrimarySymbolAliasMock.mockResolvedValue({});
   });
 
@@ -126,7 +153,7 @@ describe("createSymbol", () => {
       [{ symbolLookup: "symbol-1", date: expect.any(Date) }],
       { upsert: true },
     );
-    expect(state.upsertRows).toEqual([
+    expect(state.insertRows).toEqual([
       {
         ticker: "BP.L",
         quote_type: "EQUITY",
@@ -140,6 +167,87 @@ describe("createSymbol", () => {
         industry: "Oil & Gas Integrated",
       },
     ]);
+  });
+
+  it("refreshes the symbol behind an existing active Yahoo alias", async () => {
+    const { client, state } = createSupabaseStub();
+    createServiceClientMock.mockReturnValue(client);
+    resolveSymbolInputMock.mockResolvedValue({
+      symbol: { id: "symbol-existing" },
+    });
+    fetchYahooFinanceSymbolMock.mockResolvedValue({
+      success: true,
+      data: {
+        ticker: "BP.L",
+        quote_type: "EQUITY",
+        short_name: "BP p.l.c.",
+        long_name: "BP p.l.c.",
+        currency: "GBP",
+        quote_currency: "GBp",
+        quote_to_currency_rate: 0.01,
+        exchange: "LSE",
+        sector: "Energy",
+        industry: "Oil & Gas Integrated",
+      },
+    });
+
+    const { createSymbol } = await import("./create");
+    const result = await createSymbol("BP.L");
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { id: "symbol-existing" },
+    });
+    expect(resolveSymbolInputMock).toHaveBeenCalledWith("BP.L", {
+      source: "yahoo",
+      type: "ticker",
+      activeOnly: true,
+    });
+    expect(state.updatedIds).toEqual(["symbol-existing"]);
+    expect(state.updateRows).toHaveLength(1);
+    expect(state.insertRows).toEqual([]);
+    expect(setPrimarySymbolAliasMock).toHaveBeenCalledWith(
+      "symbol-existing",
+      "BP.L",
+      { source: "yahoo", type: "ticker" },
+    );
+  });
+
+  it("creates a fresh UUID when the matching Yahoo alias is retired", async () => {
+    const { client, state } = createSupabaseStub();
+    createServiceClientMock.mockReturnValue(client);
+    fetchYahooFinanceSymbolMock.mockResolvedValue({
+      success: true,
+      data: {
+        ticker: "REUSED",
+        quote_type: "EQUITY",
+        short_name: "New issuer",
+        long_name: "New issuer",
+        currency: "GBP",
+        quote_currency: "GBP",
+        quote_to_currency_rate: 1,
+        exchange: "LSE",
+        sector: null,
+        industry: null,
+      },
+    });
+
+    const { createSymbol } = await import("./create");
+    const result = await createSymbol("REUSED");
+
+    expect(result).toMatchObject({ success: true, data: { id: "symbol-1" } });
+    expect(resolveSymbolInputMock).toHaveBeenCalledWith("REUSED", {
+      source: "yahoo",
+      type: "ticker",
+      activeOnly: true,
+    });
+    expect(state.insertRows).toHaveLength(1);
+    expect(state.updateRows).toEqual([]);
+    expect(setPrimarySymbolAliasMock).toHaveBeenCalledWith(
+      "symbol-1",
+      "REUSED",
+      { source: "yahoo", type: "ticker" },
+    );
   });
 
   it("accepts a symbol whose Yahoo quote unit normalizes to supported KWD", async () => {
@@ -165,7 +273,7 @@ describe("createSymbol", () => {
     const result = await createSymbol("NBK.KW");
 
     expect(result.success).toBe(true);
-    expect(state.upsertRows[0]).toMatchObject({
+    expect(state.insertRows[0]).toMatchObject({
       ticker: "NBK.KW",
       currency: "KWD",
       quote_currency: "KWF",

--- a/server/symbols/create.ts
+++ b/server/symbols/create.ts
@@ -3,7 +3,10 @@
 import { getCurrentUser } from "@/server/auth/actions";
 import { fetchYahooFinanceSymbol } from "@/server/symbols/search";
 import { fetchCurrencies } from "@/server/currencies/fetch";
-import { setPrimarySymbolAlias } from "@/server/symbols/resolve";
+import {
+  resolveSymbolInput,
+  setPrimarySymbolAlias,
+} from "@/server/symbols/resolve";
 import { fetchQuotes } from "@/server/quotes/fetch";
 import { createServiceClient } from "@/supabase/service";
 
@@ -46,26 +49,34 @@ export async function createSymbol(symbolTicker: string) {
     };
   }
 
-  // 3) Insert/update symbol metadata and fetch canonical row. The Yahoo fetcher
-  // already returns a DB insert payload with normalized ISO currency plus the
-  // original provider quote unit and multiplier.
-  const { data: upsertedSymbol, error: upsertError } = await supabase
-    .from("symbols")
-    .upsert(symbolData, { onConflict: "ticker" })
-    .select("*")
-    .single();
+  // 3) Refresh only the canonical symbol behind the active Yahoo alias. A
+  // retired alias with the same ticker belongs to historical identity, so a
+  // reused ticker creates a fresh UUID instead of overwriting that row.
+  const existing = await resolveSymbolInput(symbolData.ticker, {
+    source: "yahoo",
+    type: "ticker",
+    activeOnly: true,
+  });
+  const { data: savedSymbol, error: saveError } = existing?.symbol.id
+    ? await supabase
+        .from("symbols")
+        .update(symbolData)
+        .eq("id", existing.symbol.id)
+        .select("*")
+        .single()
+    : await supabase.from("symbols").insert(symbolData).select("*").single();
 
-  if (upsertError || !upsertedSymbol) {
+  if (saveError || !savedSymbol) {
     return {
       success: false,
-      code: upsertError?.code || "SYMBOL_UPSERT_FAILED",
-      message: upsertError?.message || "Failed to create symbol",
+      code: saveError?.code || "SYMBOL_UPSERT_FAILED",
+      message: saveError?.message || "Failed to create or refresh symbol",
     };
   }
 
   // 4) Ensure a primary ticker alias exists and points to the latest value
   try {
-    await setPrimarySymbolAlias(upsertedSymbol.id, symbolData.ticker, {
+    await setPrimarySymbolAlias(savedSymbol.id, symbolData.ticker, {
       source: "yahoo",
       type: "ticker",
     });
@@ -85,7 +96,7 @@ export async function createSymbol(symbolTicker: string) {
   // the first page-render quote fetch and flags fresh imports as stale.
   // Best-effort: quote availability must not block symbol creation.
   try {
-    await fetchQuotes([{ symbolLookup: upsertedSymbol.id, date: new Date() }], {
+    await fetchQuotes([{ symbolLookup: savedSymbol.id, date: new Date() }], {
       upsert: true,
     });
   } catch (quoteError) {
@@ -95,5 +106,5 @@ export async function createSymbol(symbolTicker: string) {
     );
   }
 
-  return { success: true, data: upsertedSymbol };
+  return { success: true, data: savedSymbol };
 }

--- a/server/symbols/resolve.test.ts
+++ b/server/symbols/resolve.test.ts
@@ -8,6 +8,7 @@ type SymbolRow = {
 };
 
 type SymbolAliasRow = {
+  id?: string;
   symbol_id: string;
   value: string;
   type: string;
@@ -347,6 +348,90 @@ describe("resolveSymbolsBatch", () => {
     expect(state.symbolAliasesQueryCount).toBe(3);
   });
 
+  it("uses the active alias for a reused ticker while UUIDs keep old history", async () => {
+    const oldSymbolId = "11111111-1111-1111-1111-111111111111";
+    const newSymbolId = "22222222-2222-2222-2222-222222222222";
+    const { client } = createSupabaseStub({
+      symbols: [
+        { id: oldSymbolId, ticker: "REUSE" },
+        { id: newSymbolId, ticker: "REUSE" },
+      ],
+      symbolAliases: [
+        {
+          id: "alias-old",
+          symbol_id: oldSymbolId,
+          value: "REUSE",
+          type: "ticker",
+          source: "yahoo",
+          is_primary: true,
+          effective_from: "2025-01-01T00:00:00.000Z",
+          effective_to: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "alias-new",
+          symbol_id: newSymbolId,
+          value: "REUSE",
+          type: "ticker",
+          source: "yahoo",
+          is_primary: true,
+          effective_from: "2026-02-01T00:00:00.000Z",
+          effective_to: null,
+        },
+      ],
+    });
+
+    createServiceClientMock.mockResolvedValue(client);
+    const { resolveSymbolsBatch } = await import("./resolve");
+
+    const result = await resolveSymbolsBatch(["reuse", oldSymbolId]);
+
+    expect(result.byInput.get("reuse")?.canonicalId).toBe(newSymbolId);
+    expect(result.byInput.get(oldSymbolId)).toMatchObject({
+      canonicalId: oldSymbolId,
+      providerAlias: "REUSE",
+      displayTicker: "REUSE",
+    });
+  });
+
+  it("uses alias ID as the final provider tie-break", async () => {
+    const symbolId = "33333333-3333-3333-3333-333333333333";
+    const { client } = createSupabaseStub({
+      symbols: [{ id: symbolId, ticker: "PRIMARY" }],
+      symbolAliases: [
+        {
+          id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          symbol_id: symbolId,
+          value: "FIRST",
+          type: "ticker",
+          source: "yahoo",
+          is_primary: true,
+          effective_from: "2026-01-01T00:00:00.000Z",
+          effective_to: null,
+        },
+        {
+          id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          symbol_id: symbolId,
+          value: "SECOND",
+          type: "ticker",
+          source: "yahoo",
+          is_primary: false,
+          effective_from: "2026-01-01T00:00:00.000Z",
+          effective_to: null,
+        },
+      ],
+    });
+
+    createServiceClientMock.mockResolvedValue(client);
+    const { resolveSymbolsBatch } = await import("./resolve");
+
+    const result = await resolveSymbolsBatch([symbolId]);
+
+    expect(result.byInput.get(symbolId)).toMatchObject({
+      providerAlias: "SECOND",
+      displayTicker: "FIRST",
+    });
+  });
+
   it("falls back to primary alias and ticker when provider alias is missing", async () => {
     const symbolIdPrimaryFallback = "33333333-3333-3333-3333-333333333333";
     const symbolIdTickerFallback = "44444444-4444-4444-4444-444444444444";
@@ -667,7 +752,7 @@ describe("upsertSymbolAlias", () => {
     );
   });
 
-  it("refreshes an active alias even when it was saved from another source", async () => {
+  it("keeps broker aliases scoped to their source", async () => {
     const insertMock = vi.fn();
     const existingAlias = {
       id: "alias-1",
@@ -689,16 +774,17 @@ describe("upsertSymbolAlias", () => {
           select() {
             return {
               eq(column: string, value: unknown) {
-                expect(column).not.toBe("source");
-                expect(["symbol_id", "type", "value"].includes(column)).toBe(
-                  true,
-                );
+                expect(
+                  ["symbol_id", "type", "source", "value"].includes(column),
+                ).toBe(true);
                 expect(value).toBe(
                   column === "symbol_id"
                     ? "symbol-1"
                     : column === "type"
                       ? "isin"
-                      : "US0000000001",
+                      : column === "source"
+                        ? "trade_republic"
+                        : "US0000000001",
                 );
                 return this;
               },
@@ -710,7 +796,7 @@ describe("upsertSymbolAlias", () => {
               limit(value: number) {
                 expect(value).toBe(1);
                 return Promise.resolve({
-                  data: [existingAlias],
+                  data: [],
                   error: null,
                 });
               },
@@ -734,7 +820,20 @@ describe("upsertSymbolAlias", () => {
               },
             };
           },
-          insert: insertMock,
+          insert(payload: Record<string, unknown>) {
+            insertMock(payload);
+            return {
+              select() {
+                return this;
+              },
+              single() {
+                return Promise.resolve({
+                  data: { id: "alias-2", ...payload },
+                  error: null,
+                });
+              },
+            };
+          },
         };
       },
     });
@@ -746,10 +845,17 @@ describe("upsertSymbolAlias", () => {
     });
 
     expect(result).toMatchObject({
-      id: "alias-1",
-      source: "other_broker",
-      effective_to: null,
+      id: "alias-2",
+      source: "trade_republic",
     });
-    expect(insertMock).not.toHaveBeenCalled();
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        symbol_id: "symbol-1",
+        value: "US0000000001",
+        type: "isin",
+        source: "trade_republic",
+        is_primary: false,
+      }),
+    );
   });
 });

--- a/server/symbols/resolve.ts
+++ b/server/symbols/resolve.ts
@@ -29,6 +29,7 @@ export interface ResolveSymbolOptions {
   source?: string;
   type?: string;
   includeAliases?: boolean;
+  activeOnly?: boolean;
 }
 
 export interface ProviderAliasOptions {
@@ -57,6 +58,11 @@ interface SymbolResolutionMetadata {
   quoteToCurrencyRate: number;
 }
 
+type AliasPriorityRow = Pick<
+  SymbolAlias,
+  "id" | "source" | "type" | "is_primary" | "effective_from" | "effective_to"
+>;
+
 /**
  * Resolve a user or provider supplied identifier to the canonical symbol UUID.
  * Accepts UUIDs directly; otherwise looks up an alias of the requested type/source.
@@ -78,12 +84,7 @@ export async function resolveSymbolInput(
     });
   }
 
-  let query = supabase
-    .from("symbol_aliases")
-    .select("*, symbol:symbols (*)")
-    .order("is_primary", { ascending: false })
-    .order("effective_to", { ascending: true, nullsFirst: true })
-    .limit(1);
+  let query = supabase.from("symbol_aliases").select("*, symbol:symbols (*)");
 
   if (type) {
     query = query.eq("type", type);
@@ -91,6 +92,10 @@ export async function resolveSymbolInput(
 
   if (options.source) {
     query = query.eq("source", options.source);
+  }
+
+  if (options.activeOnly) {
+    query = query.is("effective_to", null);
   }
 
   const { data: aliasRows, error } = await query.ilike("value", normalized);
@@ -101,8 +106,10 @@ export async function resolveSymbolInput(
     );
   }
 
-  const aliasWithSymbol = aliasRows?.[0] as
-    (SymbolAlias & { symbol: Symbol }) | undefined;
+  const aliasWithSymbol = selectPreferredAlias(
+    (aliasRows ?? []) as Array<SymbolAlias & { symbol: Symbol }>,
+    { requestedSource: options.source, type },
+  );
   if (!aliasWithSymbol) return null;
 
   const { symbol, ...alias } = aliasWithSymbol;
@@ -179,6 +186,7 @@ export async function getProviderSymbolAlias(
     .eq("symbol_id", symbolId)
     .eq("source", source)
     .order("effective_from", { ascending: false })
+    .order("id", { ascending: false })
     .limit(1);
 
   if (options.type) {
@@ -231,7 +239,10 @@ export async function setPrimarySymbolAlias(
     .select("*")
     .eq("symbol_id", symbolId)
     .eq("type", type)
+    .eq("source", source)
     .eq("value", normalizedValue)
+    .is("effective_to", null)
+    .limit(1)
     .maybeSingle();
 
   if (fetchError) {
@@ -304,6 +315,7 @@ export async function upsertSymbolAlias(
     .select("*")
     .eq("symbol_id", symbolId)
     .eq("type", type)
+    .eq("source", source)
     .eq("value", normalizedValue)
     .is("effective_to", null)
     .limit(1);
@@ -471,6 +483,7 @@ export async function resolveSymbolsBatch(
     const canonicalByAliasLookup = await fetchCanonicalIdsByAliasLookups(
       supabase,
       aliasLookups,
+      provider,
     );
     const unresolvedAliasLookups = aliasLookups.filter(
       (aliasLookup) => !canonicalByAliasLookup.has(aliasLookup),
@@ -482,6 +495,7 @@ export async function resolveSymbolsBatch(
         await fetchCanonicalIdsByAliasLookupsCaseInsensitive(
           supabase,
           unresolvedAliasLookups,
+          provider,
         );
       caseInsensitiveMatches.forEach((canonicalId, aliasLookup) => {
         if (!canonicalByAliasLookup.has(aliasLookup)) {
@@ -614,6 +628,7 @@ export async function resolveSymbolsBatch(
 async function fetchCanonicalIdsByAliasLookups(
   supabase: SupabaseClient<Database>,
   aliasLookups: string[],
+  requestedSource: string,
 ) {
   const canonicalByAliasLookup = new Map<string, string>();
   if (!aliasLookups.length) return canonicalByAliasLookup;
@@ -621,12 +636,11 @@ async function fetchCanonicalIdsByAliasLookups(
   for (const aliasChunk of chunkArray(aliasLookups, BATCH_QUERY_CHUNK_SIZE)) {
     const { data, error } = await supabase
       .from("symbol_aliases")
-      .select("value, symbol_id, is_primary, effective_to")
+      .select(
+        "id, value, symbol_id, source, type, is_primary, effective_from, effective_to",
+      )
       .eq("type", DEFAULT_ALIAS_TYPE)
-      .in("value", aliasChunk)
-      .order("value", { ascending: true })
-      .order("is_primary", { ascending: false })
-      .order("effective_to", { ascending: true, nullsFirst: true });
+      .in("value", aliasChunk);
 
     if (error) {
       throw new Error(
@@ -634,10 +648,24 @@ async function fetchCanonicalIdsByAliasLookups(
       );
     }
 
+    const preferredByValue = new Map<
+      string,
+      NonNullable<typeof data>[number]
+    >();
     data?.forEach((row) => {
-      if (!canonicalByAliasLookup.has(row.value)) {
-        canonicalByAliasLookup.set(row.value, row.symbol_id);
+      const preferred = preferredByValue.get(row.value);
+      if (
+        !preferred ||
+        compareAliasPriority(row, preferred, {
+          requestedSource,
+          type: DEFAULT_ALIAS_TYPE,
+        }) < 0
+      ) {
+        preferredByValue.set(row.value, row);
       }
+    });
+    preferredByValue.forEach((row, value) => {
+      canonicalByAliasLookup.set(value, row.symbol_id);
     });
   }
 
@@ -647,6 +675,7 @@ async function fetchCanonicalIdsByAliasLookups(
 async function fetchCanonicalIdsByAliasLookupsCaseInsensitive(
   supabase: SupabaseClient<Database>,
   aliasLookups: string[],
+  requestedSource: string,
 ) {
   const canonicalByAliasLookup = new Map<string, string>();
   if (!aliasLookups.length) return canonicalByAliasLookup;
@@ -654,11 +683,10 @@ async function fetchCanonicalIdsByAliasLookupsCaseInsensitive(
   for (const aliasLookup of aliasLookups) {
     const { data, error } = await supabase
       .from("symbol_aliases")
-      .select("value, symbol_id, is_primary, effective_to")
+      .select(
+        "id, value, symbol_id, source, type, is_primary, effective_from, effective_to",
+      )
       .eq("type", DEFAULT_ALIAS_TYPE)
-      .order("is_primary", { ascending: false })
-      .order("effective_to", { ascending: true, nullsFirst: true })
-      .limit(1)
       .ilike("value", aliasLookup);
 
     if (error) {
@@ -667,8 +695,12 @@ async function fetchCanonicalIdsByAliasLookupsCaseInsensitive(
       );
     }
 
-    if (data?.[0]) {
-      canonicalByAliasLookup.set(aliasLookup, data[0].symbol_id);
+    const preferred = selectPreferredAlias(data ?? [], {
+      requestedSource,
+      type: DEFAULT_ALIAS_TYPE,
+    });
+    if (preferred) {
+      canonicalByAliasLookup.set(aliasLookup, preferred.symbol_id);
     }
   }
 
@@ -748,13 +780,14 @@ async function fetchProviderAliasesBySymbolId(
   for (const symbolIdChunk of chunkArray(symbolIds, BATCH_QUERY_CHUNK_SIZE)) {
     const { data, error } = await supabase
       .from("symbol_aliases")
-      .select("symbol_id, value, effective_from")
+      .select("id, symbol_id, value, effective_from")
       .eq("source", provider)
       .eq("type", providerType)
       .is("effective_to", null)
       .in("symbol_id", symbolIdChunk)
       .order("symbol_id", { ascending: true })
-      .order("effective_from", { ascending: false });
+      .order("effective_from", { ascending: false })
+      .order("id", { ascending: false });
 
     if (error) {
       throw new Error(
@@ -770,6 +803,53 @@ async function fetchProviderAliasesBySymbolId(
   }
 
   return providerAliasBySymbolId;
+}
+
+function selectPreferredAlias<T extends AliasPriorityRow>(
+  aliases: T[],
+  options: { requestedSource?: string; type: string },
+): T | undefined {
+  return aliases.reduce<T | undefined>((preferred, alias) => {
+    if (!preferred) return alias;
+    return compareAliasPriority(alias, preferred, options) < 0
+      ? alias
+      : preferred;
+  }, undefined);
+}
+
+function compareAliasPriority(
+  left: AliasPriorityRow,
+  right: AliasPriorityRow,
+  options: { requestedSource?: string; type: string },
+) {
+  const booleanPriorities: Array<[boolean, boolean]> = [
+    [left.effective_to === null, right.effective_to === null],
+    [
+      left.source === options.requestedSource,
+      right.source === options.requestedSource,
+    ],
+    [
+      !options.requestedSource &&
+        options.type === DEFAULT_ALIAS_TYPE &&
+        left.source === DEFAULT_ALIAS_SOURCE,
+      !options.requestedSource &&
+        options.type === DEFAULT_ALIAS_TYPE &&
+        right.source === DEFAULT_ALIAS_SOURCE,
+    ],
+    [left.is_primary, right.is_primary],
+  ];
+
+  for (const [leftWins, rightWins] of booleanPriorities) {
+    if (leftWins !== rightWins) return leftWins ? -1 : 1;
+  }
+
+  const leftEffectiveAt = left.effective_to ?? left.effective_from;
+  const rightEffectiveAt = right.effective_to ?? right.effective_from;
+  if (leftEffectiveAt !== rightEffectiveAt) {
+    return rightEffectiveAt.localeCompare(leftEffectiveAt);
+  }
+
+  return right.id.localeCompare(left.id);
 }
 
 // Both alias types normalize identically: symbols and provider aliases are

--- a/supabase/migrations/20260722110857_support_symbol_ticker_reuse.sql
+++ b/supabase/migrations/20260722110857_support_symbol_ticker_reuse.sql
@@ -1,0 +1,33 @@
+begin;
+
+do $$
+declare
+  active_duplicates text;
+begin
+  select string_agg(
+    format('%s/%s/%s (%s rows)', source, type, value, row_count),
+    ', '
+    order by source, type, value
+  )
+  into active_duplicates
+  from (
+    select source, type, value, count(*) as row_count
+    from public.symbol_aliases
+    where effective_to is null
+    group by source, type, value
+    having count(*) > 1
+  ) duplicates;
+
+  if active_duplicates is not null then
+    raise exception 'Active symbol alias duplicates must be retired before migration: %', active_duplicates;
+  end if;
+end $$;
+
+alter table public.symbols
+  drop constraint symbols_ticker_key;
+
+create unique index symbol_aliases_active_source_type_value_key
+  on public.symbol_aliases (source, type, value)
+  where effective_to is null;
+
+commit;

--- a/supabase/migrations/20260722110857_support_symbol_ticker_reuse.sql
+++ b/supabase/migrations/20260722110857_support_symbol_ticker_reuse.sql
@@ -23,6 +23,17 @@ begin
   end if;
 end $$;
 
+drop index public.symbol_aliases_symbol_type_value_effective_to_idx;
+
+create unique index symbol_aliases_symbol_source_type_value_effective_to_idx
+  on public.symbol_aliases (
+    symbol_id,
+    source,
+    type,
+    value,
+    coalesce(effective_to, 'infinity'::timestamptz)
+  );
+
 alter table public.symbols
   drop constraint symbols_ticker_key;
 

--- a/supabase/migrations/20260722110857_support_symbol_ticker_reuse.sql
+++ b/supabase/migrations/20260722110857_support_symbol_ticker_reuse.sql
@@ -13,13 +13,14 @@ begin
   from (
     select source, type, value, count(*) as row_count
     from public.symbol_aliases
-    where effective_to is null
+    where type = 'ticker'
+      and effective_to is null
     group by source, type, value
     having count(*) > 1
   ) duplicates;
 
   if active_duplicates is not null then
-    raise exception 'Active symbol alias duplicates must be retired before migration: %', active_duplicates;
+    raise exception 'Active ticker alias duplicates must be retired before migration: %', active_duplicates;
   end if;
 end $$;
 
@@ -37,8 +38,9 @@ create unique index symbol_aliases_symbol_source_type_value_effective_to_idx
 alter table public.symbols
   drop constraint symbols_ticker_key;
 
-create unique index symbol_aliases_active_source_type_value_key
-  on public.symbol_aliases (source, type, value)
-  where effective_to is null;
+create unique index symbol_aliases_active_ticker_source_value_key
+  on public.symbol_aliases (source, value)
+  where type = 'ticker'
+    and effective_to is null;
 
 commit;


### PR DESCRIPTION
## Summary

Closes out the production log remediation: enables safe ticker reuse after
delistings and tightens symbol resolution to active Yahoo listings. Also
includes minor market-data badge refinements from local UX testing.

### Ticker reuse & active alias resolution

- **Migration** (`20260722110857_support_symbol_ticker_reuse.sql`):
  - Drops the global `symbols_ticker_key` unique constraint — tickers are no
    longer the identity of a security; canonical UUIDs are.
  - Adds a partial unique index on `symbol_aliases (source, type, value)
    WHERE effective_to IS NULL` — at most one *active* alias per provider
    ticker; retired aliases may share values with newer securities.
  - In-transaction preflight aborts with a named list if active duplicates
    exist (none do — verified in production).
- **`createSymbol()` no longer upserts by ticker.** It resolves the active
  Yahoo alias: updates that canonical symbol if found, otherwise inserts a
  fresh UUID. A retired alias can never cause the historical security to be
  overwritten by a reused ticker.
- **Deterministic alias selection** everywhere (single, batch, case-insensitive,
  provider lookups): active first → requested source → Yahoo for
  source-unspecified tickers → primary → most recently effective/retired →
  alias id.
- **Association flows resolve active listings only** (position create, CSV
  import, update-symbol, broker instrument resolution). Retired/delisted
  tickers fail with a clear error instead of silently attaching to historical
  identity. Explicit UUIDs still resolve to their canonical historical
  security; display/historical paths keep active-first fallback.
- Docs: symbol lifecycle updated (`docs/SYMBOL-RENAME-HANDLING.md`),
  product reference updated for the AI advisor.

### Market data badge refinements

- Unavailable badge is icon-only in table rows (matching the stale badge
  footprint) and shows a short "No market data" label on the asset header.
- Fact-first tooltips on both states; instructional copy lives in the dialog
  only.

## Deployment

⚠️ **Deploy first, then apply the migration.** The currently deployed
`createSymbol` uses `ON CONFLICT (ticker)`, which fails once the constraint
is dropped. The new code runs fine against the old schema, so the correct
order is: merge → Vercel deploy live → run migration against production.

## Testing

- Full suite: 609/609 passing against regenerated types (no type diff — the
  migration changes no columns).
- Typecheck, lint, and format checks clean.
- New coverage: reused-ticker creation (new UUID), retired-old vs active-new
  resolution, deterministic legacy-case lookup, broker-import selection,
  badge rendering states.
- Migration applied and verified on local database.