### PR TITLE
feat(categories): offer to create the searched category

### DIFF
--- a/components/dashboard/categories/create-category-dialog.tsx
+++ b/components/dashboard/categories/create-category-dialog.tsx
@@ -22,6 +22,9 @@ interface CreateCategoryDialogProps {
   onOpenChange: (open: boolean) => void;
   positionType: "asset" | "liability";
   onCreated: (category: { id: string; name: string }) => void | Promise<void>;
+  // Only read on mount, so callers that need to seed it must mount the dialog
+  // when they open it.
+  defaultName?: string;
 }
 
 export function CreateCategoryDialog({
@@ -29,8 +32,9 @@ export function CreateCategoryDialog({
   onOpenChange,
   positionType,
   onCreated,
+  defaultName = "",
 }: CreateCategoryDialogProps) {
-  const [newCategoryName, setNewCategoryName] = useState("");
+  const [newCategoryName, setNewCategoryName] = useState(defaultName);
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 

--- a/components/dashboard/categories/position-category-selector.test.tsx
+++ b/components/dashboard/categories/position-category-selector.test.tsx
@@ -158,6 +158,61 @@ describe("PositionCategorySelector", () => {
     expect(onUserCategoryChange).toHaveBeenCalledWith("custom-2");
   });
 
+  it("offers to create the searched term when no category matches", async () => {
+    const onChange = vi.fn();
+    const onUserCategoryChange = vi.fn();
+    mocks.createUserPositionCategory.mockResolvedValue({
+      success: true,
+      created: true,
+      category: {
+        id: "custom-2",
+        name: "Wine",
+      },
+    });
+
+    render(
+      <PositionCategorySelector
+        field={{ value: "equity", onChange }}
+        userCategoryId={null}
+        onUserCategoryChange={onUserCategoryChange}
+        allowCustomCategories
+      />,
+    );
+
+    openSelector();
+    fireEvent.change(screen.getByPlaceholderText("Search category..."), {
+      target: { value: "Wine" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Retirement")).toBeNull();
+    });
+    expect(screen.queryByText("No categories found.")).toBeNull();
+
+    // Keeping the row inside the command list keeps it keyboard reachable.
+    const createOption = screen
+      .getByText('Create "Wine"')
+      .closest('[role="option"]');
+    expect(createOption?.getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.click(screen.getByText('Create "Wine"'));
+
+    // The dialog opens prefilled with the search term.
+    const nameInput = screen.getByLabelText("Name") as HTMLInputElement;
+    expect(nameInput.value).toBe("Wine");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mocks.createUserPositionCategory).toHaveBeenCalledWith({
+        name: "Wine",
+        positionType: "asset",
+      });
+    });
+    expect(onChange).toHaveBeenCalledWith("other");
+    expect(onUserCategoryChange).toHaveBeenCalledWith("custom-2");
+  });
+
   it("does not submit a parent form when creating a custom category", async () => {
     const onParentSubmit = vi.fn((event: SyntheticEvent<HTMLFormElement>) => {
       event.preventDefault();

--- a/components/dashboard/categories/position-category-selector.test.tsx
+++ b/components/dashboard/categories/position-category-selector.test.tsx
@@ -213,6 +213,25 @@ describe("PositionCategorySelector", () => {
     expect(onUserCategoryChange).toHaveBeenCalledWith("custom-2");
   });
 
+  it("offers the searched term even when the search matches the add new row", () => {
+    render(
+      <PositionCategorySelector
+        field={{ value: "equity", onChange: vi.fn() }}
+        allowCustomCategories
+      />,
+    );
+
+    openSelector();
+    // "new" would match the add new row's own value, which used to keep the
+    // empty state from rendering.
+    fireEvent.change(screen.getByPlaceholderText("Search category..."), {
+      target: { value: "new" },
+    });
+
+    expect(screen.getByText('Create "new"')).toBeTruthy();
+    expect(screen.queryByText("Add new")).toBeNull();
+  });
+
   it("does not submit a parent form when creating a custom category", async () => {
     const onParentSubmit = vi.fn((event: SyntheticEvent<HTMLFormElement>) => {
       event.preventDefault();

--- a/components/dashboard/categories/position-category-selector.tsx
+++ b/components/dashboard/categories/position-category-selector.tsx
@@ -142,8 +142,7 @@ function PositionCategoryList({
   refreshCategories,
 }: CategoryListProps) {
   const [search, setSearch] = useState("");
-  // Holds the name the create dialog opens with; null keeps the dialog closed.
-  const [createDialogName, setCreateDialogName] = useState<string | null>(null);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
 
   const searchTerm = search.trim();
@@ -217,7 +216,7 @@ function PositionCategoryList({
               <CommandGroup forceMount>
                 <CommandItem
                   value="create-searched-category"
-                  onSelect={() => setCreateDialogName(searchTerm)}
+                  onSelect={() => setCreateDialogOpen(true)}
                 >
                   <PlusIcon />
                   {searchTerm ? `Create "${searchTerm}"` : "Add new"}
@@ -265,15 +264,19 @@ function PositionCategoryList({
                     {category.name}
                   </CommandItem>
                 ))}
-                <CommandItem
-                  onSelect={() => {
-                    setCreateDialogName("");
-                  }}
-                  value="add-new-custom-category"
-                >
-                  <PlusIcon />
-                  Add new
-                </CommandItem>
+                {/* Hidden while searching: this row's value would otherwise
+                    match searches like "new" or "custom" and keep the empty
+                    state (which offers to create the searched term) from
+                    rendering. */}
+                {!searchTerm && (
+                  <CommandItem
+                    onSelect={() => setCreateDialogOpen(true)}
+                    value="add-new-custom-category"
+                  >
+                    <PlusIcon />
+                    Add new
+                  </CommandItem>
+                )}
               </CommandGroup>
             </>
           )}
@@ -281,17 +284,17 @@ function PositionCategoryList({
       </Command>
 
       {/* Mounted on open so the dialog seeds its name input from the search. */}
-      {createDialogName !== null && (
+      {createDialogOpen && (
         <CreateCategoryDialog
           open
           onOpenChange={(nextOpen) => {
             if (!nextOpen) {
-              setCreateDialogName(null);
+              setCreateDialogOpen(false);
               setOpen(false);
             }
           }}
           positionType={positionType}
-          defaultName={createDialogName}
+          defaultName={searchTerm}
           onCreated={handleCategoryCreated}
         />
       )}

--- a/components/dashboard/categories/position-category-selector.tsx
+++ b/components/dashboard/categories/position-category-selector.tsx
@@ -141,8 +141,12 @@ function PositionCategoryList({
   allowCustomCategories,
   refreshCategories,
 }: CategoryListProps) {
-  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  // Holds the name the create dialog opens with; null keeps the dialog closed.
+  const [createDialogName, setCreateDialogName] = useState<string | null>(null);
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
+
+  const searchTerm = search.trim();
 
   const systemCategories = categories.filter(
     (category) => category.source === "system",
@@ -191,11 +195,36 @@ function PositionCategoryList({
   return (
     <>
       <Command>
-        <CommandInput placeholder="Search category..." className="h-9" />
+        <CommandInput
+          placeholder="Search category..."
+          className="h-9"
+          value={search}
+          onValueChange={setSearch}
+        />
         <CommandList>
-          <CommandEmpty>
-            {isLoading ? "Loading categories..." : "No categories found."}
-          </CommandEmpty>
+          {isLoading || !allowCustomCategories ? (
+            <CommandEmpty>
+              {isLoading ? "Loading categories..." : "No categories found."}
+            </CommandEmpty>
+          ) : (
+            // A search that matches nothing offers to create that category
+            // instead of dead-ending on "No categories found.". forceMount
+            // keeps the row out of cmdk's filter, so the empty state (which
+            // only renders while no item matches) stays visible around it. The
+            // group wrapper is required: cmdk reorders items by score and only
+            // handles items that sit inside a group or at the list root.
+            <CommandEmpty className="p-0 text-left">
+              <CommandGroup forceMount>
+                <CommandItem
+                  value="create-searched-category"
+                  onSelect={() => setCreateDialogName(searchTerm)}
+                >
+                  <PlusIcon />
+                  {searchTerm ? `Create "${searchTerm}"` : "Add new"}
+                </CommandItem>
+              </CommandGroup>
+            </CommandEmpty>
+          )}
           <CommandGroup heading="System Categories">
             {systemCategories.map((category) => (
               <CommandItem
@@ -238,7 +267,7 @@ function PositionCategoryList({
                 ))}
                 <CommandItem
                   onSelect={() => {
-                    setCreateDialogOpen(true);
+                    setCreateDialogName("");
                   }}
                   value="add-new-custom-category"
                 >
@@ -251,17 +280,21 @@ function PositionCategoryList({
         </CommandList>
       </Command>
 
-      <CreateCategoryDialog
-        open={createDialogOpen}
-        onOpenChange={(nextOpen) => {
-          setCreateDialogOpen(nextOpen);
-          if (!nextOpen) {
-            setOpen(false);
-          }
-        }}
-        positionType={positionType}
-        onCreated={handleCategoryCreated}
-      />
+      {/* Mounted on open so the dialog seeds its name input from the search. */}
+      {createDialogName !== null && (
+        <CreateCategoryDialog
+          open
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) {
+              setCreateDialogName(null);
+              setOpen(false);
+            }
+          }}
+          positionType={positionType}
+          defaultName={createDialogName}
+          onCreated={handleCategoryCreated}
+        />
+      )}
 
       <ManageCategoriesDialog
         open={manageDialogOpen}

--- a/content/product-reference.md
+++ b/content/product-reference.md
@@ -50,16 +50,16 @@ Three ways to add an asset:
 
 ### Field meanings
 
-| Field                  | Meaning                                              | Rules                                                                                          |
-| ---------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Name                   | Position name                                        | 3–64 characters                                                                                |
-| Category               | Asset class used for allocation charts               | Pick one; custom categories supported                                                          |
-| Currency               | The position's accounting currency                   | 3-letter ISO 4217 code (USD, EUR, GBP, …), must be supported                                   |
-| Quantity               | Number of units/shares held                          | ≥ 0                                                                                            |
-| Unit value             | Current value of one unit                            | ≥ 0; auto-fetched for symbol-backed positions                                                  |
-| Cost basis per unit    | What you paid per unit (your average purchase price) | Optional; must be > 0 if provided. Used to compute profit/loss and estimated capital gains tax |
-| Capital gains tax rate | Your tax rate on gains for this position             | Optional; entered as a percentage 0–100 in forms                                               |
-| Description            | Free-form note                                       | Max 256 characters                                                                             |
+| Field                  | Meaning                                              | Rules                                                                                                                |
+| ---------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Name                   | Position name                                        | 3–64 characters                                                                                                      |
+| Category               | Asset class used for allocation charts               | Pick one; custom categories supported — create one from the selector, or straight from a search that matches nothing |
+| Currency               | The position's accounting currency                   | 3-letter ISO 4217 code (USD, EUR, GBP, …), must be supported                                                         |
+| Quantity               | Number of units/shares held                          | ≥ 0                                                                                                                  |
+| Unit value             | Current value of one unit                            | ≥ 0; auto-fetched for symbol-backed positions                                                                        |
+| Cost basis per unit    | What you paid per unit (your average purchase price) | Optional; must be > 0 if provided. Used to compute profit/loss and estimated capital gains tax                       |
+| Capital gains tax rate | Your tax rate on gains for this position             | Optional; entered as a percentage 0–100 in forms                                                                     |
+| Description            | Free-form note                                       | Max 256 characters                                                                                                   |
 
 **Cash and single items:** either set quantity to the balance with unit value 1 (e.g. quantity 5000, unit value 1), or quantity 1 with unit value equal to the total (e.g. a house: quantity 1, unit value 8,200,000). Both work; total value = quantity × unit value.
 


### PR DESCRIPTION
## What

Searching the position category selector for a category that doesn't exist used to dead-end on "No categories found.". When custom categories are allowed, the empty state now renders a create row for the typed term instead:

- Typing `Wine` with no match shows `+ Create "Wine"` in place of the empty message.
- Selecting it opens the create dialog **prefilled** with `Wine`, so the name isn't retyped.
- The `Add new` row in the Custom Categories group is unchanged with an empty search, but is hidden while searching — the empty-state row is the only create affordance during a search (see the P2 thread below).
- The import review table (`allowCustomCategories={false}`, no create option) keeps "No categories found.", and the loading state keeps "Loading categories...".

## How

- `position-category-selector.tsx`: the search input is now controlled so the term can be shown and reused. The create row is `forceMount`ed so cmdk's filter leaves it alone — that's what keeps the empty state (which only renders while no item matches) visible around it. It is wrapped in a `forceMount` group because cmdk's score-based reordering calls `appendChild` with the result of `closest('[cmdk-group-items=""] > *')` and throws on an item that sits in neither a group nor the list root.
- The group's `Add new` row renders only with an empty search. Its cmdk value (`add-new-custom-category`) otherwise matched searches like `new`, `custom` or `category`, which kept `filtered.count` above zero and stopped the empty state — and the create dialog — from ever seeing those terms. Hiding it takes the action row out of filtering entirely, and lets both entry points seed from the same trimmed search term with a plain boolean for the dialog's open state.
- `create-category-dialog.tsx`: new optional `defaultName` prop, read once via the state initializer. The selector therefore mounts the dialog on open; the tradeoff is losing its close animation.
- `content/product-reference.md`: the Category rules cell now mentions creating a category straight from an unmatched search, so the AI advisor can answer for the new path.

## Testing

- Two new unit tests: searching an unmatched term shows `Create "Wine"`, keeps it keyboard-selectable (`aria-selected`), suppresses "No categories found.", prefills the dialog and creates + selects the category; and searching `new` — which collides with the `Add new` row's own value — still offers `Create "new"`. The first caught the cmdk `appendChild` crash described above before it shipped.
- Locally: 6 selector tests and all 76 dashboard component tests pass, `eslint` and `prettier --check` clean.
- CI is green on `cda00a6` across Vitest, Lint/Format/Type, Docker build and CodeQL. (An earlier note here about local `xlsx` test/type failures was a sandbox artifact — that host is unreachable from the dev container, so `xlsx` was never installed; CI resolves it fine.)