### PR TITLE
fix(ai-chat): fill available height and stop tool header overflow

### DIFF
--- a/app/(dashboard)/dashboard/ai-chat/page.tsx
+++ b/app/(dashboard)/dashboard/ai-chat/page.tsx
@@ -16,20 +16,20 @@ export default function AIChatPage() {
     sanitizeDashboardReturnPath(requestedReturnPath) ?? "/dashboard";
 
   return (
+    // flex-1 + min-h-0: the conversation scroller hides its content height
+    // from layout (that's what makes internal scrolling work), so a
+    // content-sized card collapses to the header + composer once a
+    // conversation is active. Fill the available height instead.
     // contain-size: without it the chat's content height propagates up as the
     // layout wrapper's min-content, making the whole shell scroll instead of
     // capping the card at the available height.
-    <div className="flex min-h-0 flex-1 flex-col justify-center contain-size">
-      {/* Single-cell grid: the panel stretches to the card, while the card
-          stays content-sized between the min-height floor and available space. */}
-      <div className="bg-primary-foreground mx-auto grid min-h-[min(70dvh,100%)] w-full max-w-3xl overflow-hidden rounded-lg border">
-        <AIChatPanel
-          layoutMode="page"
-          isAIEnabled={profile.data_sharing_consent}
-          initialConversationId={requestedConversationId}
-          moveToSidebarHref={moveToSidebarHref}
-        />
-      </div>
+    <div className="bg-primary-foreground mx-auto grid min-h-0 w-full max-w-3xl flex-1 overflow-hidden rounded-lg border contain-size">
+      <AIChatPanel
+        layoutMode="page"
+        isAIEnabled={profile.data_sharing_consent}
+        initialConversationId={requestedConversationId}
+        moveToSidebarHref={moveToSidebarHref}
+      />
     </div>
   );
 }

--- a/app/(dashboard)/dashboard/ai-chat/page.tsx
+++ b/app/(dashboard)/dashboard/ai-chat/page.tsx
@@ -16,20 +16,22 @@ export default function AIChatPage() {
     sanitizeDashboardReturnPath(requestedReturnPath) ?? "/dashboard";
 
   return (
-    // flex-1 + min-h-0: the conversation scroller hides its content height
-    // from layout (that's what makes internal scrolling work), so a
-    // content-sized card collapses to the header + composer once a
-    // conversation is active. Fill the available height instead.
     // contain-size: without it the chat's content height propagates up as the
     // layout wrapper's min-content, making the whole shell scroll instead of
     // capping the card at the available height.
-    <div className="bg-primary-foreground mx-auto grid min-h-0 w-full max-w-3xl flex-1 overflow-hidden rounded-lg border contain-size">
-      <AIChatPanel
-        layoutMode="page"
-        isAIEnabled={profile.data_sharing_consent}
-        initialConversationId={requestedConversationId}
-        moveToSidebarHref={moveToSidebarHref}
-      />
+    <div className="flex min-h-0 flex-1 flex-col justify-center contain-size">
+      {/* Mobile: the card always fills the available height. From md up it is
+          content-sized from a 70dvh floor and grows with the conversation
+          until flex shrink caps it at the available height. Growth relies on
+          the thread using a content-based flex basis (see chat.tsx). */}
+      <div className="bg-primary-foreground mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col overflow-hidden rounded-lg border md:min-h-[min(70dvh,100%)] md:flex-initial">
+        <AIChatPanel
+          layoutMode="page"
+          isAIEnabled={profile.data_sharing_consent}
+          initialConversationId={requestedConversationId}
+          moveToSidebarHref={moveToSidebarHref}
+        />
+      </div>
     </div>
   );
 }

--- a/components/ai-elements/tool.tsx
+++ b/components/ai-elements/tool.tsx
@@ -79,14 +79,14 @@ export const ToolHeader = ({
     )}
     {...props}
   >
-    <div className="flex min-w-0 items-center gap-2">
-      <FoliofoxIcon height={24} className="shrink-0" />
-      <span className="truncate font-medium text-sm">
+    <div className="flex items-center gap-2">
+      <FoliofoxIcon height={24}/>
+      <span className="font-medium text-sm">
         {title ?? type.split("-").slice(1).join("-")}
       </span>
       {getStatusBadge(state)}
     </div>
-    <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+    <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
   </CollapsibleTrigger>
 );
 

--- a/components/ai-elements/tool.tsx
+++ b/components/ai-elements/tool.tsx
@@ -79,14 +79,14 @@ export const ToolHeader = ({
     )}
     {...props}
   >
-    <div className="flex items-center gap-2">
-      <FoliofoxIcon height={24}/>
-      <span className="font-medium text-sm">
+    <div className="flex min-w-0 items-center gap-2">
+      <FoliofoxIcon height={24} className="shrink-0" />
+      <span className="truncate font-medium text-sm">
         {title ?? type.split("-").slice(1).join("-")}
       </span>
       {getStatusBadge(state)}
     </div>
-    <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+    <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
   </CollapsibleTrigger>
 );
 

--- a/components/dashboard/ai-chat/chat.tsx
+++ b/components/dashboard/ai-chat/chat.tsx
@@ -427,7 +427,13 @@ export function Chat({
     <>
       <Conversation
         className={cn(
-          "min-h-0 flex-1 overflow-hidden",
+          // flex-auto, not flex-1: a content-based flex basis lets the
+          // thread's height propagate to the page card, which is
+          // content-sized on desktop and grows with the conversation.
+          // Safari treats a 0% basis as zero intrinsic height, which
+          // collapses the card to its min-height floor. Inside a
+          // definite-height container the final layout is identical.
+          "min-h-0 flex-auto overflow-hidden",
           isLoadingConversation && "pointer-events-none opacity-50",
         )}
       >

--- a/components/dashboard/ai-chat/message.tsx
+++ b/components/dashboard/ai-chat/message.tsx
@@ -209,10 +209,13 @@ export function ChatMessage({
               return (
                 <Fragment key={`${message.id}-part-${index}`}>
                   <Tool className="notranslate mb-0" translate="no">
+                    {/* Child selectors reach into the vendored ToolHeader
+                        (icon + name + badge row) so the tool name truncates
+                        instead of overflowing on narrow screens. */}
                     <ToolHeader
                       type={part.type}
                       state={part.state}
-                      className="truncate"
+                      className="[&>div]:min-w-0 [&>div>span]:truncate [&>div>svg]:shrink-0 [&>svg]:shrink-0"
                     />
                     <ToolContent>
                       <ToolInput input={part.input} />


### PR DESCRIPTION
The chat card was content-sized with a min-h floor, but the conversation
scroller hides its content height from layout, so with an active
conversation the card collapsed to the 70dvh floor and floated centered
with dead space around it on small screens. Make the card fill the
available height instead and let messages scroll inside it.

The tool header row (icon + name + status badge) had no shrinkable
element, so long tool names pushed the card wider than slim viewports.
Allow the name to truncate and pin the icon and chevron sizes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wixv6hpYTksNBA4ZjhzpyK